### PR TITLE
Refine circle

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -227,7 +227,6 @@ workflows:
             branches:
               ignore: main
       - build_and_push:
-          context: laa-hmrc-interface-uat
           filters:
             branches:
               ignore: main
@@ -249,7 +248,6 @@ workflows:
             branches:
               only: main
       - build_and_push:
-          context: laa-hmrc-interface-uat
           requires:
             - lint_checks
             - unit_tests


### PR DESCRIPTION
This removes contexts from build and push steps, the
values have now been re-located in circle ci
and should not require a context to successfully
complete

The strange branch name is to test the deletion of a previously
created database under this branch name :+1: