### PR TITLE
Update branch_name handling

### DIFF
--- a/bin/uat_deploy
+++ b/bin/uat_deploy
@@ -4,6 +4,11 @@ deploy() {
   IMG_REPO="$ECR_ENDPOINT/laa-apply-for-legal-aid/laa-hmrc-interface-uat-ecr"
   RELEASE_NAME=$(echo $CIRCLE_BRANCH | sed 's:^\w*\/::' | tr -s ' _/[]().' '-' | cut -c1-30 | sed 's/-$//')
   RELEASE_HOST="$RELEASE_NAME-laa-hmrc-interface-uat.apps.live-1.cloud-platform.service.justice.gov.uk"
+  BRANCH_NAME=$(echo $CIRCLE_BRANCH | tr -s ' _/[]().' '-')
+  if [[ $(echo $BRANCH_NAME | awk -F/ '{print NF-1}')  != '0' ]]
+  then
+    BRANCH_NAME="$(echo $BRANCH_NAME | awk -F/ '{print $1}')-$(echo $BRANCH_NAME | awk -F/ '{print $NF}')"
+  fi
 
   echo "Deploying CIRCLE_SHA1: $CIRCLE_SHA1 under release name: '$RELEASE_NAME'..."
 
@@ -15,7 +20,7 @@ deploy() {
                 --set image.repository="$IMG_REPO" \
                 --set image.tag="$CIRCLE_SHA1" \
                 --set ingress.hosts="{$RELEASE_HOST}" \
-                --set branch.name="$CIRCLE_BRANCH"
+                --set branch.name="$BRANCH_NAME"
 }
 
 deploy


### PR DESCRIPTION
Ensure that long names or those with unsupported characters
are sanitized.

Given a branch name X it will return Y
* dependabot/bundler/main/bootsnap-1.7.4 => dependabot-bundler-main-bootsnap-1-7-4
* ap-1234/feature-name => ap-1234-feature-name
* feature-name => feature-name