### PR TITLE
Add authentication and authorisation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ ruby '3.0.1'
 gem 'bootsnap', '>= 1.4.4', require: false
 gem 'config'
 gem 'dotenv-rails'
+gem 'jwt'
 gem 'pg', '~> 1.1'
 gem 'puma', '~> 5.3'
 gem 'rails', '~> 6.1.4'
@@ -31,6 +32,8 @@ group :development, :test do
 end
 
 group :test do
+  gem 'factory_bot_rails'
+  gem 'faker'
   gem 'mock_redis'
   gem 'rspec-rails', '~> 5.0'
   gem 'rspec-sidekiq'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -124,6 +124,13 @@ GEM
       http_parser.rb (~> 0.6.0)
     erubi (1.10.0)
     eventmachine (1.2.7)
+    factory_bot (6.2.0)
+      activesupport (>= 5.0.0)
+    factory_bot_rails (6.2.0)
+      factory_bot (~> 6.2.0)
+      railties (>= 5.0.0)
+    faker (2.18.0)
+      i18n (>= 1.6, < 2)
     faraday (1.5.1)
       faraday-em_http (~> 1.0)
       faraday-em_synchrony (~> 1.0)
@@ -175,6 +182,7 @@ GEM
     http_parser.rb (0.6.0)
     i18n (1.8.10)
       concurrent-ruby (~> 1.0)
+    jwt (2.2.3)
     listen (3.6.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
@@ -370,10 +378,13 @@ DEPENDENCIES
   byebug
   config
   dotenv-rails
+  factory_bot_rails
+  faker
   guard-livereload
   guard-rspec
   guard-rubocop
   highline
+  jwt
   listen (~> 3.6)
   mock_redis
   pg (~> 1.1)

--- a/app/controllers/use_case_one_controller.rb
+++ b/app/controllers/use_case_one_controller.rb
@@ -1,0 +1,75 @@
+class UseCaseOneController < ApplicationController
+  def create
+    raise 'Unauthorised' unless validate_params
+
+    render status: :ok,
+           json: {
+             success: true,
+             message: 'Successfully Authenticated, '\
+                      'now we would call a service to begin the authentication and' \
+                      'start the tree walking required by the HMRC interactions'
+           }
+  rescue RuntimeError
+    render json: { errors: ['Not Authenticated'] }, status: :unauthorized
+  end
+
+  private
+
+  def validate_params
+    validate_access_key && validate_data
+  end
+
+  def validate_data
+    data_param_present? &&
+      data_param_encoded_by_application_user? &&
+      decoded_data_matches_schema?
+  end
+
+  def data_param_present?
+    data_param.present?
+  end
+
+  def data_param_encoded_by_application_user?
+    decoded_data.present?
+  end
+
+  def decoded_data_matches_schema?
+    decoded_data.first.keys.sort.eql?(%w[dob first_name from last_name nino to])
+  end
+
+  def decoded_data
+    @decoded_data ||= JWT.decode(data_param, application_user.secret_key, true, { algorithm: 'HS512' })
+  rescue JWT::VerificationError
+    false
+  end
+
+  def validate_access_key
+    key_is_present? && application_user_exists? && application_user_has_permission?
+  end
+
+  def application_user_exists?
+    application_user.present?
+  end
+
+  def application_user_has_permission?
+    application_user.use_cases.include?(1)
+  end
+
+  def application_user
+    @application_user ||= ApplicationUser.find_by(access_key: access_key_param)
+  end
+
+  def key_is_present?
+    access_key_param.present?
+  end
+
+  def access_key_param
+    request.headers['Authorization']
+  end
+
+  def data_param
+    return nil if params[:data].blank?
+
+    @data_param ||= params.require(:data)
+  end
+end

--- a/app/models/application_user.rb
+++ b/app/models/application_user.rb
@@ -1,0 +1,5 @@
+class ApplicationUser < ApplicationRecord
+  serialize :use_cases
+
+  validates :use_cases, presence: true, inclusion: { in: (1..4) }
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -39,5 +39,8 @@ module LaaHmrcInterfaceServiceApi
     # Middleware like session, flash, cookies can be added back manually.
     # Skip views, helpers and assets when generating a new resource.
     config.api_only = true
+    config.generators do |g|
+      g.orm :active_record, primary_key_type: :uuid, foreign_key_type: :uuid
+    end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -22,6 +22,7 @@ Rails.application.routes.draw do
   get 'health_check', to: 'status#health_check', format: :json
   get 'status', to: 'status#ping', format: :json
   get 'smoke-test', to: 'smoke_test#call', format: :json unless Settings.environment.eql?('live')
+  resources :use_case_one, only: %i[create], format: :json
 end
 
 def secure_compare(passed, stored)

--- a/db/migrate/20210426070241_enable_pgcrypto.rb
+++ b/db/migrate/20210426070241_enable_pgcrypto.rb
@@ -1,0 +1,5 @@
+class EnablePgcrypto < ActiveRecord::Migration[6.1]
+  def change
+    enable_extension 'pgcrypto'
+  end
+end

--- a/db/migrate/20210426070457_create_application_users.rb
+++ b/db/migrate/20210426070457_create_application_users.rb
@@ -1,0 +1,12 @@
+class CreateApplicationUsers < ActiveRecord::Migration[6.1]
+  def change
+    create_table :application_users, id: :uuid do |t|
+      t.string :name
+      t.string :access_key
+      t.string :secret_key
+      t.text :use_cases, default: [].to_yaml
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,19 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 0) do
+ActiveRecord::Schema.define(version: 2021_04_26_070457) do
 
   # These are extensions that must be enabled in order to support this database
+  enable_extension "pgcrypto"
   enable_extension "plpgsql"
+
+  create_table "application_users", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.string "name"
+    t.string "access_key"
+    t.string "secret_key"
+    t.text "use_cases", default: "--- []\n"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
 
 end

--- a/spec/factories/application_user.rb
+++ b/spec/factories/application_user.rb
@@ -1,0 +1,8 @@
+FactoryBot.define do
+  factory :application_user do
+    name { Faker::Company.name }
+    access_key { SecureRandom.hex(13) }
+    secret_key { Faker::Blockchain::Tezos.secret_key }
+    use_cases { [1] }
+  end
+end

--- a/spec/models/application_user_spec.rb
+++ b/spec/models/application_user_spec.rb
@@ -1,0 +1,31 @@
+require 'rails_helper'
+
+describe ApplicationUser, :model do
+  subject { described_class.new }
+
+  describe 'use case validation' do
+    context 'can have multiple values 1-4' do
+      subject(:multiple_use_cases) { build :application_user, use_cases: [1, 2, 3, 4] }
+
+      it { is_expected.to be_valid }
+    end
+
+    describe 'fails if mix of valid and invalid values' do
+      subject(:use_cases) { build :application_user, use_cases: %i[1 two] }
+
+      it { expect(subject.valid?).to be false }
+    end
+
+    describe 'fails if non-numeric values' do
+      subject(:use_cases) { build :application_user, use_cases: %i[one two] }
+
+      it { expect(subject.valid?).to be false }
+    end
+
+    describe 'fails if text values' do
+      subject(:use_cases) { build :application_user, use_cases: %w[hello] }
+
+      it { is_expected.to be_invalid }
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -61,4 +61,6 @@ RSpec.configure do |config|
   config.filter_rails_from_backtrace!
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
+
+  config.include FactoryBot::Syntax::Methods
 end

--- a/spec/requests/use_case_one_controller_spec.rb
+++ b/spec/requests/use_case_one_controller_spec.rb
@@ -1,0 +1,106 @@
+require 'rails_helper'
+
+describe UseCaseOneController, type: :request do
+  describe 'POST /use_case_one' do
+    subject(:post_uc1) { post use_case_one_index_path, params: params, headers: headers }
+    let(:headers) { { authorization: access_key } }
+    let(:params) { { data: jwt } }
+    let(:application_user) { create :application_user }
+    let(:access_key) { application_user.access_key }
+    let(:jwt) { create_jwt_with(request_hash, application_user.secret_key) }
+    let(:request_hash) do
+      {
+        first_name: 'fname',
+        last_name: 'lname',
+        dob: '1990-01-01',
+        nino: 'QQ123456C',
+        from: '2020-01-01',
+        to: '2020-04-01'
+      }
+    end
+    before { post_uc1 }
+
+    describe 'unauthorized checks' do
+      context 'when no params are sent' do
+        let(:params) { nil }
+
+        it 'returns unauthorized' do
+          expect(response).to have_http_status(:unauthorized)
+        end
+      end
+
+      context 'when no access_key is sent' do
+        let(:access_key) { '' }
+
+        it 'returns unauthorized' do
+          expect(response).to have_http_status(:unauthorized)
+        end
+      end
+
+      context 'when nil access_key is sent' do
+        let(:access_key) { nil }
+
+        it 'returns unauthorized' do
+          expect(response).to have_http_status(:unauthorized)
+        end
+      end
+
+      context 'when no data is sent' do
+        let(:jwt) { '' }
+
+        it 'returns unauthorized' do
+          expect(response).to have_http_status(:unauthorized)
+        end
+      end
+
+      context 'when nil data is sent' do
+        let(:jwt) { nil }
+
+        it 'returns unauthorized' do
+          expect(response).to have_http_status(:unauthorized)
+        end
+      end
+
+      context 'when data encoded with the wrong key is sent' do
+        let(:jwt) { create_jwt_with(request_hash, 'incorrect_secret_key') }
+
+        it 'returns unauthorized' do
+          expect(response).to have_http_status(:unauthorized)
+        end
+      end
+
+      context 'when data encoded with the wrong keys is sent' do
+        let(:request_hash) do
+          {
+            first_name: 'fname',
+            malicious_name: 'lname',
+            dob: '1990-01-01',
+            nino: 'QQ123456C',
+            from: '2020-01-01',
+            to: '2020-04-01'
+          }
+        end
+
+        it 'returns unauthorized' do
+          expect(response).to have_http_status(:unauthorized)
+        end
+      end
+
+      context 'when the application_user does not have the correct use_case' do
+        let(:application_user) { create :application_user, use_cases: [2] }
+
+        it 'returns unauthorized' do
+          expect(response).to have_http_status(:unauthorized)
+        end
+      end
+    end
+
+    it 'returns success' do
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+  def create_jwt_with(payload, secret)
+    JWT.encode payload, secret, 'HS512'
+  end
+end


### PR DESCRIPTION
Add an ApplicationUser model this will store roles (use_cases)
along with access and secret keys

Add an example UseCaseOneController that will expect an application
to submit an access_key in the header and correctly sign a JWT with
it's secret_key and submit via the parameters

## Usage
Once an application_user has been created, they could submit a request like so: 
```sh
curl --request POST 'host/use_case_one' \
--header 'Authorization: application_user.secret_key_from_service' \
--header 'Content-Type: application/json' \
--data-raw '{"data":"eyJhbGciOiJIUzUxMiIsInR5cCI6IkpXVCJ9.eyJmaXJzdF9uYW1lIjoiZm5hbWUiLCJsYXN0X25hbWUiOiJsbmFtZSIsImRvYiI6IjE5OTAtMDEtMDEiLCJuaW5vIjoiUVExMjM0NTZDIiwiZnJvbSI6IjIwMjAtMDEtMDEiLCJ0byI6IjIwMjAtMDQtMDEifQ.0N28FagllUZoq9r2P4z1bsmij2Q99IAZYJdHgHZXMk-ogdICMkHSAYaYDc3PpqpDFVK8jLVCIjPCZf8x2g9e4A"}'
```
**Note**: the JWT was generated with fake-secret-key and doesn't expose anything 'real'