### PR TITLE
Add a standalone script for running sandbox tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,12 @@
 # Ignore master key for decrypting credentials and more.
 /config/master.key
 
+# Ignore simplecov coverage stats
+/coverage/
+
 config/settings.local.yml
 config/settings/*.local.yml
 config/environments/*.local.yml
+
+# ignore legacy script outputs
+user_data/**.*

--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,8 @@ gem 'puma', '~> 5.3'
 gem 'rails', '~> 6.1.4'
 gem 'redis'
 gem 'redis-namespace'
+gem 'rest-client'
+gem 'rotp'
 gem 'sentry-rails'
 gem 'sentry-ruby'
 gem 'sidekiq'
@@ -33,6 +35,7 @@ group :test do
   gem 'rspec-rails', '~> 5.0'
   gem 'simplecov', require: false
   gem 'simplecov-rcov'
+  gem 'webmock'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -60,6 +60,8 @@ GEM
       minitest (>= 5.1)
       tzinfo (~> 2.0)
       zeitwerk (~> 2.3)
+    addressable (2.7.0)
+      public_suffix (>= 2.0.2, < 5.0)
     ast (2.4.2)
     bootsnap (1.7.5)
       msgpack (~> 1.0)
@@ -71,10 +73,14 @@ GEM
       deep_merge (~> 1.2, >= 1.2.1)
       dry-validation (~> 1.0, >= 1.0.0)
     connection_pool (2.2.5)
+    crack (0.4.5)
+      rexml
     crass (1.0.6)
     deep_merge (1.2.1)
     diff-lcs (1.4.4)
     docile (1.3.5)
+    domain_name (0.5.20190701)
+      unf (>= 0.0.5, < 1.0.0)
     dotenv (2.7.6)
     dotenv-rails (2.7.6)
       dotenv (= 2.7.6)
@@ -157,7 +163,11 @@ GEM
     guard-rubocop (1.4.0)
       guard (~> 2.0)
       rubocop (< 2.0)
+    hashdiff (1.0.1)
     highline (2.0.3)
+    http-accept (1.7.0)
+    http-cookie (1.0.3)
+      domain_name (~> 0.5)
     http_parser.rb (0.6.0)
     i18n (1.8.10)
       concurrent-ruby (~> 1.0)
@@ -172,6 +182,9 @@ GEM
       mini_mime (>= 0.1.1)
     marcel (1.0.1)
     method_source (1.0.0)
+    mime-types (3.3.1)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2021.0225)
     mini_mime (1.1.0)
     minitest (5.14.4)
     mock_redis (0.28.0)
@@ -180,6 +193,7 @@ GEM
     multi_json (1.15.0)
     multipart-post (2.1.1)
     nenv (0.3.0)
+    netrc (0.11.0)
     nio4r (2.5.7)
     nokogiri (1.11.7-x86_64-darwin)
       racc (~> 1.4)
@@ -198,6 +212,7 @@ GEM
     pry-byebug (3.9.0)
       byebug (~> 11.0)
       pry (~> 0.13.0)
+    public_suffix (4.0.6)
     puma (5.3.2)
       nio4r (~> 2.0)
     racc (1.5.2)
@@ -239,7 +254,13 @@ GEM
     redis-namespace (1.8.1)
       redis (>= 3.0.4)
     regexp_parser (2.1.1)
+    rest-client (2.1.0)
+      http-accept (>= 1.7.0, < 2.0)
+      http-cookie (>= 1.0.2, < 2.0)
+      mime-types (>= 1.16, < 4.0)
+      netrc (~> 0.8)
     rexml (3.2.5)
+    rotp (6.2.0)
     rspec (3.10.0)
       rspec-core (~> 3.10.0)
       rspec-expectations (~> 3.10.0)
@@ -319,7 +340,14 @@ GEM
       concurrent-ruby (~> 1.0)
     tzinfo-data (1.2021.1)
       tzinfo (>= 1.0.0)
+    unf (0.1.4)
+      unf_ext
+    unf_ext (0.0.7.7)
     unicode-display_width (2.0.0)
+    webmock (3.12.2)
+      addressable (>= 2.3.6)
+      crack (>= 0.3.2)
+      hashdiff (>= 0.4.0, < 2.0.0)
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
@@ -347,6 +375,8 @@ DEPENDENCIES
   rails (~> 6.1.4)
   redis
   redis-namespace
+  rest-client
+  rotp
   rspec-rails (~> 5.0)
   rspec_junit_formatter
   rubocop
@@ -359,6 +389,7 @@ DEPENDENCIES
   simplecov-rcov
   spring
   tzinfo-data
+  webmock
 
 RUBY VERSION
    ruby 3.0.1p64

--- a/README.md
+++ b/README.md
@@ -16,3 +16,19 @@ This Service facilitates the HMRC API access for the LAA Use Cases
 * Run the tests with `bundle exec rspec`
 * Run the server with `bundle exec rails s`
 
+### Stand-alone test
+
+A test script has been added to run a single test on use_case one
+It can be run from a rails console with 
+```ruby 
+ApplyGetTest.call(
+  first_name: 'first', 
+  last_name: 'name', 
+  nino: 'QQ123456C', 
+  dob: '1990-01-01', 
+  start_date: '2021-01-01', 
+  end_date: '2021-03-31'
+)
+```
+
+As long as the current dev/uat environment has the correct use case one configuration in settings a series of calls will be made to obtain, format and display the pre-created sandbox data

--- a/app/services/apply_get_test.rb
+++ b/app/services/apply_get_test.rb
@@ -1,0 +1,99 @@
+# :nocov:
+class ApplyGetTest
+  attr_reader :data
+
+  def initialize(**args)
+    return unless args.keys.difference(%i[first_name last_name nino dob start_date end_date]).empty?
+
+    @use_case = UseCase.new(:one)
+    @data = JSON.parse({
+      first_name: args[:first_name],
+      last_name: args[:last_name],
+      nino: args[:nino],
+      dob: args[:dob],
+      start_date: args[:start_date],
+      end_date: args[:end_date]
+    }.to_json, object_class: OpenStruct)
+  end
+
+  def self.call(**args)
+    new(**args).call
+  end
+
+  def call
+    @correlation_id = SecureRandom.uuid
+    @result = {}
+    user_match_id = request_match_id
+    data = request_endpoint(user_match_id)
+    next_links = extract_next_links(data)
+    loop_each next_links
+
+    Rails.logger.info JSON.pretty_generate(JSON.parse(@result.to_json))
+    Rails.logger.info 'done'
+  end
+
+  private
+
+  def loop_each(array_of_urls)
+    array_of_urls.each do |uri|
+      parsed_uri = build_uri(uri)
+      data = request_endpoint(parsed_uri.for_calling)
+      extract_data_from(data, parsed_uri)
+      next_links = extract_next_links(data)
+      loop_each next_links if next_links.any?
+    end
+  end
+
+  def extract_data_from(data, parsed_uri)
+    return if data.except('_links').keys.empty?
+
+    key = [parsed_uri.for_displaying, data.except('_links').keys.first].join('/').tr('-', '_')
+    value = data[data.except('_links').keys.first].first
+    @result[key] = value
+  end
+
+  def request_endpoint(uri)
+    response = RestClient.get("#{host}#{uri}", Endpoint::Headers.call(uri, @correlation_id, @token))
+    JSON.parse(response)
+  rescue RestClient::TooManyRequests
+    Rails.logger.info "Rate limited while calling #{uri}: waiting then trying again"
+    sleep(0.33)
+    request_endpoint(uri)
+  end
+
+  def request_match_id
+    uri = '/individuals/matching'
+    response = RestClient.post("#{host}#{uri}", request_payload, build_headers(uri))
+    JSON.parse(response, object_class: OpenStruct)._links.individual.href
+  end
+
+  def request_payload
+    {
+      firstName: data.first_name,
+      lastName: data.last_name,
+      nino: data.nino,
+      dateOfBirth: data.dob
+    }.to_json
+  end
+
+  def extract_next_links(data)
+    data['_links'].filter_map { |x| x[1]['href'] unless x[0].eql?('self') }
+  end
+
+  def build_uri(uri)
+    Endpoint::Uri.new(uri, use_case: @use_case.use_case, from_date: data.start_date, to_date: data.end_date)
+  end
+
+  def build_headers(uri)
+    Endpoint::Headers.call(uri, @correlation_id, token)
+  end
+
+  def host
+    @host ||= @use_case.host
+  end
+
+  def token
+    @token ||= @use_case.bearer_token
+  end
+end
+# :nocov:

--- a/app/services/bearer_token.rb
+++ b/app/services/bearer_token.rb
@@ -1,0 +1,38 @@
+class BearerToken
+  def initialize(for_use_case)
+    raise 'Unsupported UseCase' unless for_use_case.eql?('use_case_one')
+
+    @credentials = Settings.credentials.send(for_use_case)
+  end
+
+  def self.call(for_use_case)
+    new(for_use_case).call
+  end
+
+  def call
+    response = RestClient.post(url, payload)
+    parsed_json = JSON.parse(response.body)
+    parsed_json['access_token']
+  end
+
+  private
+
+  def payload
+    {
+      grant_type: 'client_credentials',
+      client_secret: "#{totp.now}#{@credentials.hmrc_client_secret}",
+      client_id: @credentials.hmrc_client_id
+    }
+  end
+
+  def totp
+    ROTP::TOTP.new(@credentials.hmrc_totp_secret,
+                   digits: 8,
+                   digest: 'sha512',
+                   issuer: @credentials.description)
+  end
+
+  def url
+    "#{@credentials.host}/oauth/token"
+  end
+end

--- a/app/services/endpoint/headers.rb
+++ b/app/services/endpoint/headers.rb
@@ -1,0 +1,41 @@
+module Endpoint
+  class Headers
+    def initialize(href, correlation_id, token)
+      @href = href
+      @correlation_id = correlation_id
+      @token = token
+    end
+
+    def call
+      result = base_headers
+      result.merge!(@href.include?('benefits-and-credits') ? v1_headers : v2_headers)
+      result.merge!(content_type) if @href.match?(%r{individuals/matching$})
+      result
+    end
+
+    def self.call(href, correlation_id, token)
+      new(href, correlation_id, token).call
+    end
+
+    private
+
+    def base_headers
+      {
+        correlationId: @correlation_id.to_s,
+        Authorization: "Bearer #{@token}"
+      }
+    end
+
+    def content_type
+      { content_type: 'application/json' }
+    end
+
+    def v1_headers
+      { accept: 'application/vnd.hmrc.1.0+json' }
+    end
+
+    def v2_headers
+      { accept: 'application/vnd.hmrc.2.0+json' }
+    end
+  end
+end

--- a/app/services/endpoint/tax_years_for.rb
+++ b/app/services/endpoint/tax_years_for.rb
@@ -1,0 +1,26 @@
+module Endpoint
+  class TaxYearsFor
+    attr_accessor :date
+
+    def initialize(date)
+      @date = date
+    end
+
+    def self.call(date)
+      new(date).call
+    end
+
+    def call
+      year = date.year # set the current year by default
+      year -= 1 if date_is_pre_april_6th # reduce by a year if the month is pre-april-6th
+      financial_year_start = Date.new(year, 4, 1)
+      "#{financial_year_start.year}-#{(financial_year_start + 1.year).strftime('%y')}"
+    end
+
+    private
+
+    def date_is_pre_april_6th
+      date.month < 4 || date.month.eql?(4) && date.day < 6
+    end
+  end
+end

--- a/app/services/endpoint/uri.rb
+++ b/app/services/endpoint/uri.rb
@@ -23,18 +23,11 @@ module Endpoint
     private
 
     def tax_years_from
-      tax_years_for(Date.parse(@options[:from_date]))
+      TaxYearsFor.call(Date.parse(@options[:from_date]))
     end
 
     def tax_years_to
-      tax_years_for(Date.parse(@options[:to_date]))
-    end
-
-    def tax_years_for(date)
-      year = date.year # set the current year by default
-      year -= 1 if date.month < 4 # reduce by a year if the month is pre-april
-      financial_year_start = Date.new(year, 4, 1)
-      "#{financial_year_start.year}-#{(financial_year_start + 1.year).strftime('%y')}"
+      TaxYearsFor.call(Date.parse(@options[:to_date]))
     end
   end
 end

--- a/app/services/endpoint/uri.rb
+++ b/app/services/endpoint/uri.rb
@@ -1,0 +1,40 @@
+module Endpoint
+  class Uri
+    def initialize(href, **args)
+      @href = href
+      @options = args
+    end
+
+    def for_calling
+      case @href
+      when /{&fromDate,toDate}/
+        @href.gsub!('{&fromDate,toDate}', "&fromDate=#{@options[:from_date]}&toDate=#{@options[:to_date]}")
+      when /{&fromTaxYear,toTaxYear}/
+        @href.gsub!('{&fromTaxYear,toTaxYear}', "&fromTaxYear=#{tax_years_from}&toTaxYear=#{tax_years_to}")
+      else
+        @href
+      end
+    end
+
+    def for_displaying
+      Rack::Utils.parse_query(@href).keys[0].gsub(/\?.*/, '').split('/')[2...].join('/')
+    end
+
+    private
+
+    def tax_years_from
+      tax_years_for(Date.parse(@options[:from_date]))
+    end
+
+    def tax_years_to
+      tax_years_for(Date.parse(@options[:to_date]))
+    end
+
+    def tax_years_for(date)
+      year = date.year # set the current year by default
+      year -= 1 if date.month < 4 # reduce by a year if the month is pre-april
+      financial_year_start = Date.new(year, 4, 1)
+      "#{financial_year_start.year}-#{(financial_year_start + 1.year).strftime('%y')}"
+    end
+  end
+end

--- a/app/services/use_case.rb
+++ b/app/services/use_case.rb
@@ -1,0 +1,30 @@
+class UseCase
+  FOUR_HOURS = 14_400 # fours hours in seconds
+
+  attr_reader :bearer_token, :use_case
+
+  def initialize(use_case)
+    @use_case = "use_case_#{use_case}"
+    @bearer_token = check_bearer_token
+  end
+
+  def host
+    @host ||= Settings.credentials.send(@use_case).host
+  end
+
+  private
+
+  def check_bearer_token
+    generate_new_token if current_token.nil?
+    current_token
+  end
+
+  def generate_new_token
+    new_token = BearerToken.call(@use_case)
+    REDIS.setex("#{@use_case}_bearer_token", FOUR_HOURS, new_token)
+  end
+
+  def current_token
+    REDIS.get("#{@use_case}_bearer_token")
+  end
+end

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -1,5 +1,5 @@
 Sentry.init do |config|
-  config.dsn = Settings.sentry.dsn
+  config.dsn = Settings.sentry.dsn unless Settings.sentry.environment.eql?('test')
   config.breadcrumbs_logger = %i[active_support_logger http_logger]
   config.environment = Settings.sentry.environment
 

--- a/spec/services/bearer_token_spec.rb
+++ b/spec/services/bearer_token_spec.rb
@@ -1,0 +1,35 @@
+require 'rails_helper'
+
+describe BearerToken do
+  subject(:bearer_token) { described_class.new('use_case_one') }
+
+  let(:fake_data) do
+    {
+      access_token: 'zz00000z00z0z00000z0z0z0000z0000',
+      token_type: 'bearer'
+      # real response has other returns but out of scope of this test
+    }.to_json
+  end
+
+  before do
+    stub_request(:post, %r{\A#{Settings.credentials.use_case_one.host}/oauth/token\z})
+      .to_return(status: 200, body: fake_data)
+  end
+
+  context 'when called with an invalid use_case' do
+    subject(:bearer_token) { described_class.new('not_a_use_case') }
+
+    it { expect { subject }.to raise_error 'Unsupported UseCase' }
+  end
+
+  describe '#call' do
+    subject(:call) { bearer_token.call }
+
+    it { is_expected.to eql 'zz00000z00z0z00000z0z0z0000z0000' }
+  end
+
+  describe '.call' do
+    subject(:call) { described_class.call('use_case_one') }
+    it { is_expected.to eql 'zz00000z00z0z00000z0z0z0000z0000' }
+  end
+end

--- a/spec/services/endpoint/headers_spec.rb
+++ b/spec/services/endpoint/headers_spec.rb
@@ -1,0 +1,82 @@
+require 'rails_helper'
+
+RSpec.describe Endpoint::Headers do
+  subject(:headers) { described_class.new(href, correlation_id, token) }
+  let(:correlation_id) { 'fake-correlation_id' }
+  let(:token) { 'fake_bearer_token' }
+
+  describe '#call' do
+    subject(:call) { described_class.call(href, correlation_id, token) }
+
+    context 'when there is no matchID' do
+      let(:href) { 'individuals/matching' }
+      let(:expected_hash) do
+        {
+          accept: 'application/vnd.hmrc.2.0+json',
+          content_type: 'application/json',
+          correlationId: 'fake-correlation_id',
+          Authorization: 'Bearer fake_bearer_token'
+        }
+      end
+
+      it { is_expected.to eql expected_hash }
+    end
+  end
+
+  describe '.call' do
+    subject(:call) { headers.call }
+
+    context 'when there is no matchID' do
+      let(:href) { 'individuals/matching' }
+      let(:expected_hash) do
+        {
+          accept: 'application/vnd.hmrc.2.0+json',
+          content_type: 'application/json',
+          correlationId: 'fake-correlation_id',
+          Authorization: 'Bearer fake_bearer_token'
+        }
+      end
+
+      it { is_expected.to eql expected_hash }
+    end
+
+    context 'when the url end with individuals/matching but has a uuid' do
+      let(:href) { 'individuals/matching/fake-uuid' }
+      let(:expected_hash) do
+        {
+          accept: 'application/vnd.hmrc.2.0+json',
+          correlationId: 'fake-correlation_id',
+          Authorization: 'Bearer fake_bearer_token'
+        }
+      end
+
+      it { is_expected.to eql expected_hash }
+    end
+
+    context 'when the url includes benefits-and-credits' do
+      let(:href) { '/root/benefits-and-credits/sub?matchId=fake-uuid' }
+      let(:expected_hash) do
+        {
+          accept: 'application/vnd.hmrc.1.0+json',
+          correlationId: 'fake-correlation_id',
+          Authorization: 'Bearer fake_bearer_token'
+        }
+      end
+
+      it { is_expected.to eql expected_hash }
+    end
+
+    context 'when the url does not include benefits-and-credits' do
+      let(:href) { '/root/employment?matchId=fake-uuid' }
+      let(:expected_hash) do
+        {
+          accept: 'application/vnd.hmrc.2.0+json',
+          correlationId: 'fake-correlation_id',
+          Authorization: 'Bearer fake_bearer_token'
+        }
+      end
+
+      it { is_expected.to eql expected_hash }
+    end
+  end
+end

--- a/spec/services/endpoint/tax_years_for_spec.rb
+++ b/spec/services/endpoint/tax_years_for_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+
+RSpec.describe Endpoint::TaxYearsFor do
+  subject(:tax_year) { described_class.call(date) }
+
+  context 'when the date is at the beginning of April' do
+    let(:date) { Date.new(2021, 4, 3) }
+
+    it 'returns the previous year to the current year' do
+      is_expected.to eql '2020-21'
+    end
+  end
+
+  context 'when the date is past April' do
+    let(:date) { Date.new(2021, 5, 3) }
+
+    it 'returns the current year to next year' do
+      is_expected.to eql '2021-22'
+    end
+  end
+end

--- a/spec/services/endpoint/uri_spec.rb
+++ b/spec/services/endpoint/uri_spec.rb
@@ -1,0 +1,58 @@
+require 'rails_helper'
+
+RSpec.describe Endpoint::Uri do
+  subject(:use_case) { described_class.new(href, use_case: 'use_case_one', from_date: from_date, to_date: to_date) }
+  let(:href) { '/root/type/sub?matchID=123456' }
+  let(:from_date) { '2021-01-01' }
+  let(:to_date) { '2021-03-31' }
+  it { is_expected.to be_a Endpoint::Uri }
+
+  describe '.for_calling' do
+    subject(:for_calling) { use_case.for_calling }
+
+    context 'when the href just has a matchID' do
+      it { is_expected.to eql '/root/type/sub?matchID=123456' }
+    end
+
+    context 'when the href has a matchID and requires dates' do
+      let(:href) { '/root/type/sub?matchID=123456{&fromDate,toDate}' }
+
+      it { is_expected.to eql '/root/type/sub?matchID=123456&fromDate=2021-01-01&toDate=2021-03-31' }
+    end
+
+    context 'when the href has a matchID and requires tax years' do
+      let(:href) { '/root/type/sub?matchID=123456{&fromTaxYear,toTaxYear}' }
+
+      it { is_expected.to eql '/root/type/sub?matchID=123456&fromTaxYear=2020-21&toTaxYear=2020-21' }
+
+      context 'when the financial years differ' do
+        let(:from_date) { '2021-02-01' }
+        let(:to_date) { '2021-04-30' }
+
+        it { is_expected.to eql '/root/type/sub?matchID=123456&fromTaxYear=2020-21&toTaxYear=2021-22' }
+      end
+    end
+  end
+
+  describe '.for_displaying' do
+    subject(:for_displaying) { use_case.for_displaying }
+
+    context 'when the href just has a matchID' do
+      let(:href) { '/root/type?matchID=123456' }
+
+      it { is_expected.to eql 'type' }
+    end
+
+    context 'when the href has a matchID and requires dates' do
+      let(:href) { '/root/type/sub?matchID=123456{&fromDate,toDate}' }
+
+      it { is_expected.to eql 'type/sub' }
+    end
+
+    context 'when the href has a matchID and requires tax years' do
+      let(:href) { '/root/type/sub?matchID=123456{&fromTaxYear,toTaxYear}' }
+
+      it { is_expected.to eql 'type/sub' }
+    end
+  end
+end

--- a/spec/services/use_case_spec.rb
+++ b/spec/services/use_case_spec.rb
@@ -1,0 +1,37 @@
+require 'rails_helper'
+
+RSpec.describe UseCase do
+  subject(:use_case) { described_class.new(:one) }
+
+  describe 'initializing' do
+    context 'when a valid bearer_token is available' do
+      before do
+        REDIS.set('use_case_one_bearer_token', 'fake_token_value')
+        subject
+      end
+
+      it 'does not call the bearer_token generator' do
+        expect(BearerToken).not_to receive(:call)
+      end
+    end
+
+    context 'when a valid bearer_token is not available' do
+      it 'calls BearerToken and stores the value in redis' do
+        expect(BearerToken).to receive(:call).with('use_case_one').and_return('new_fake_token_value')
+        expect(REDIS.get('use_case_one_bearer_token')).to be nil
+        subject
+        expect(REDIS.get('use_case_one_bearer_token')).to eql 'new_fake_token_value'
+      end
+    end
+  end
+
+  describe '.host' do
+    subject(:host) { use_case.host }
+    before do
+      REDIS.set('use_case_one_bearer_token', 'fake_token_value')
+      subject
+    end
+
+    it { is_expected.to eql Settings.credentials.use_case_one.host }
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -16,6 +16,9 @@
 
 require 'simplecov'
 require 'highline/import'
+require 'webmock'
+require 'webmock/rspec'
+WebMock.disable_net_connect!
 require 'redis'
 require 'mock_redis'
 REDIS = MockRedis.new
@@ -35,6 +38,11 @@ unless ENV['NOCOVERAGE']
 end
 
 RSpec.configure do |config|
+  # set up default stub for the host, this can be overwritten in individual stubs if needed
+  config.before do
+    stub_request(:post, %r{\A#{Settings.credentials.host}/.*\z}).to_return(status: 200, body: '')
+  end
+
   config.before(:each) do
     REDIS.flushdb
   end

--- a/user_data/jagger_stafford.user
+++ b/user_data/jagger_stafford.user
@@ -1,0 +1,337 @@
+Data for jagger stafford
+
+calling https://test-api.service.hmrc.gov.uk/individuals/matching/d668b22f-d6b2-4072-8c48-61d11799f538
+{
+  "individual": "redacted",
+  "_links": {
+    "benefits-and-credits": {
+      "name": "GET",
+      "href": "/individuals/benefits-and-credits/?matchId=d668b22f-d6b2-4072-8c48-61d11799f538",
+      "title": "Get the individual's benefits and credits data"
+    },
+    "income": {
+      "name": "GET",
+      "href": "/individuals/income/?matchId=d668b22f-d6b2-4072-8c48-61d11799f538",
+      "title": "Get the individual's income data"
+    },
+    "self": {
+      "href": "/individuals/matching/d668b22f-d6b2-4072-8c48-61d11799f538"
+    },
+    "employments": {
+      "name": "GET",
+      "href": "/individuals/employments/?matchId=d668b22f-d6b2-4072-8c48-61d11799f538",
+      "title": "Get the individual's employment data"
+    }
+  }
+}
+calling https://test-api.service.hmrc.gov.uk/individuals/benefits-and-credits/?matchId=d668b22f-d6b2-4072-8c48-61d11799f538
+{
+  "_links": {
+    "working-tax-credit": {
+      "href": "/individuals/benefits-and-credits/working-tax-credit?matchId=d668b22f-d6b2-4072-8c48-61d11799f538{&fromDate,toDate}",
+      "title": "Get Working Tax Credit details"
+    },
+    "child-tax-credit": {
+      "href": "/individuals/benefits-and-credits/child-tax-credit?matchId=d668b22f-d6b2-4072-8c48-61d11799f538{&fromDate,toDate}",
+      "title": "Get Child Tax Credit details"
+    },
+    "self": {
+      "href": "/individuals/benefits-and-credits/?matchId=d668b22f-d6b2-4072-8c48-61d11799f538"
+    }
+  }
+}
+calling https://test-api.service.hmrc.gov.uk/individuals/benefits-and-credits/working-tax-credit?matchId=d668b22f-d6b2-4072-8c48-61d11799f538&fromDate=2020-12-01&toDate=2021-02-25
+{
+  "_links": {
+    "self": {
+      "href": "/individuals/benefits-and-credits/working-tax-credits?matchId=d668b22f-d6b2-4072-8c48-61d11799f538&fromDate=2020-12-01&toDate=2021-02-25"
+    }
+  },
+  "applications": [
+
+  ]
+}
+calling https://test-api.service.hmrc.gov.uk/individuals/benefits-and-credits/child-tax-credit?matchId=d668b22f-d6b2-4072-8c48-61d11799f538&fromDate=2020-12-01&toDate=2021-02-25
+{
+  "_links": {
+    "self": {
+      "href": "/individuals/benefits-and-credits/child-tax-credits?matchId=d668b22f-d6b2-4072-8c48-61d11799f538&fromDate=2020-12-01&toDate=2021-02-25"
+    }
+  },
+  "applications": [
+
+  ]
+}
+calling https://test-api.service.hmrc.gov.uk/individuals/income/?matchId=d668b22f-d6b2-4072-8c48-61d11799f538
+{
+  "_links": {
+    "paye": {
+      "href": "/individuals/income/paye?matchId=d668b22f-d6b2-4072-8c48-61d11799f538{&fromDate,toDate}",
+      "title": "Get an individual's PAYE income data per employment"
+    },
+    "sa": {
+      "href": "/individuals/income/sa?matchId=d668b22f-d6b2-4072-8c48-61d11799f538{&fromTaxYear,toTaxYear}",
+      "title": "Get an individual's Self Assessment income data"
+    },
+    "self": {
+      "href": "/individuals/income/?matchId=d668b22f-d6b2-4072-8c48-61d11799f538"
+    }
+  }
+}
+calling https://test-api.service.hmrc.gov.uk/individuals/income/paye?matchId=d668b22f-d6b2-4072-8c48-61d11799f538&fromDate=2020-12-01&toDate=2021-02-25
+{
+  "_links": {
+    "self": {
+      "href": "/individuals/income/paye?matchId=d668b22f-d6b2-4072-8c48-61d11799f538&fromDate=2020-12-01&toDate=2021-02-25"
+    }
+  },
+  "paye": {
+    "income": [
+
+    ]
+  }
+}
+calling https://test-api.service.hmrc.gov.uk/individuals/income/sa?matchId=d668b22f-d6b2-4072-8c48-61d11799f538&fromTaxYear=2019-20&toTaxYear=2020-21&useCase=LAA-C1
+{
+  "_links": {
+    "pensionsAndStateBenefits": {
+      "href": "/individuals/income/sa/pensions-and-state-benefits?matchId=d668b22f-d6b2-4072-8c48-61d11799f538{&fromTaxYear,toTaxYear}",
+      "title": "Get an individual's SA pensions and state benefits data"
+    },
+    "source": {
+      "href": "/individuals/income/sa/source?matchId=d668b22f-d6b2-4072-8c48-61d11799f538{&fromTaxYear,toTaxYear}",
+      "title": "Get an individual's SA source data"
+    },
+    "employments": {
+      "href": "/individuals/income/sa/employments?matchId=d668b22f-d6b2-4072-8c48-61d11799f538{&fromTaxYear,toTaxYear}",
+      "title": "Get an individual's SA employments data"
+    },
+    "additionalInformation": {
+      "href": "/individuals/income/sa/additional-information?matchId=d668b22f-d6b2-4072-8c48-61d11799f538{&fromTaxYear,toTaxYear}",
+      "title": "Get an individual's SA additional information data"
+    },
+    "self": {
+      "href": "/individuals/income/sa?matchId=d668b22f-d6b2-4072-8c48-61d11799f538&fromTaxYear=2019-20&toTaxYear=2020-21"
+    },
+    "partnerships": {
+      "href": "/individuals/income/sa/partnerships?matchId=d668b22f-d6b2-4072-8c48-61d11799f538{&fromTaxYear,toTaxYear}",
+      "title": "Get an individual's SA partnerships data"
+    },
+    "ukProperties": {
+      "href": "/individuals/income/sa/uk-properties?matchId=d668b22f-d6b2-4072-8c48-61d11799f538{&fromTaxYear,toTaxYear}",
+      "title": "Get an individual's SA UK properties data"
+    },
+    "foreign": {
+      "href": "/individuals/income/sa/foreign?matchId=d668b22f-d6b2-4072-8c48-61d11799f538{&fromTaxYear,toTaxYear}",
+      "title": "Get an individual's SA foreign income data"
+    },
+    "furtherDetails": {
+      "href": "/individuals/income/sa/further-details?matchId=d668b22f-d6b2-4072-8c48-61d11799f538{&fromTaxYear,toTaxYear}",
+      "title": "Get an individual's SA further details data"
+    },
+    "interestsAndDividends": {
+      "href": "/individuals/income/sa/interests-and-dividends?matchId=d668b22f-d6b2-4072-8c48-61d11799f538{&fromTaxYear,toTaxYear}",
+      "title": "Get an individual's SA interest and dividends data"
+    },
+    "other": {
+      "href": "/individuals/income/sa/other?matchId=d668b22f-d6b2-4072-8c48-61d11799f538{&fromTaxYear,toTaxYear}",
+      "title": "Get an individual's SA other data"
+    },
+    "summary": {
+      "href": "/individuals/income/sa/summary?matchId=d668b22f-d6b2-4072-8c48-61d11799f538{&fromTaxYear,toTaxYear}",
+      "title": "Get an individual's SA summary data"
+    },
+    "trusts": {
+      "href": "/individuals/income/sa/trusts?matchId=d668b22f-d6b2-4072-8c48-61d11799f538{&fromTaxYear,toTaxYear}",
+      "title": "Get an individual's SA trusts data"
+    }
+  },
+  "selfAssessment": {
+    "registrations": [
+
+    ],
+    "taxReturns": [
+
+    ]
+  }
+}
+calling https://test-api.service.hmrc.gov.uk/individuals/income/sa/pensions-and-state-benefits?matchId=d668b22f-d6b2-4072-8c48-61d11799f538&fromTaxYear=2019-20&toTaxYear=2020-21&useCase=LAA-C1
+{
+  "_links": {
+    "self": {
+      "href": "/individuals/income/sa/pensions-and-state-benefits?matchId=d668b22f-d6b2-4072-8c48-61d11799f538&fromTaxYear=2019-20&toTaxYear=2020-21"
+    }
+  },
+  "selfAssessment": {
+    "taxReturns": [
+
+    ]
+  }
+}
+calling https://test-api.service.hmrc.gov.uk/individuals/income/sa/source?matchId=d668b22f-d6b2-4072-8c48-61d11799f538&fromTaxYear=2019-20&toTaxYear=2020-21&useCase=LAA-C1
+{
+  "_links": {
+    "self": {
+      "href": "/individuals/income/sa/source?matchId=d668b22f-d6b2-4072-8c48-61d11799f538&fromTaxYear=2019-20&toTaxYear=2020-21"
+    }
+  },
+  "selfAssessment": {
+    "taxReturns": [
+
+    ]
+  }
+}
+calling https://test-api.service.hmrc.gov.uk/individuals/income/sa/employments?matchId=d668b22f-d6b2-4072-8c48-61d11799f538&fromTaxYear=2019-20&toTaxYear=2020-21&useCase=LAA-C1
+{
+  "_links": {
+    "self": {
+      "href": "/individuals/income/sa/employments?matchId=d668b22f-d6b2-4072-8c48-61d11799f538&fromTaxYear=2019-20&toTaxYear=2020-21"
+    }
+  },
+  "selfAssessment": {
+    "taxReturns": [
+
+    ]
+  }
+}
+calling https://test-api.service.hmrc.gov.uk/individuals/income/sa/additional-information?matchId=d668b22f-d6b2-4072-8c48-61d11799f538&fromTaxYear=2019-20&toTaxYear=2020-21&useCase=LAA-C1
+{
+  "_links": {
+    "self": {
+      "href": "/individuals/income/sa/additional-information?matchId=d668b22f-d6b2-4072-8c48-61d11799f538&fromTaxYear=2019-20&toTaxYear=2020-21"
+    }
+  },
+  "selfAssessment": {
+    "taxReturns": [
+
+    ]
+  }
+}
+calling https://test-api.service.hmrc.gov.uk/individuals/income/sa/partnerships?matchId=d668b22f-d6b2-4072-8c48-61d11799f538&fromTaxYear=2019-20&toTaxYear=2020-21&useCase=LAA-C1
+{
+  "_links": {
+    "self": {
+      "href": "/individuals/income/sa/partnerships?matchId=d668b22f-d6b2-4072-8c48-61d11799f538&fromTaxYear=2019-20&toTaxYear=2020-21"
+    }
+  },
+  "selfAssessment": {
+    "taxReturns": [
+
+    ]
+  }
+}
+calling https://test-api.service.hmrc.gov.uk/individuals/income/sa/uk-properties?matchId=d668b22f-d6b2-4072-8c48-61d11799f538&fromTaxYear=2019-20&toTaxYear=2020-21&useCase=LAA-C1
+{
+  "_links": {
+    "self": {
+      "href": "/individuals/income/sa/uk-properties?matchId=d668b22f-d6b2-4072-8c48-61d11799f538&fromTaxYear=2019-20&toTaxYear=2020-21"
+    }
+  },
+  "selfAssessment": {
+    "taxReturns": [
+
+    ]
+  }
+}
+calling https://test-api.service.hmrc.gov.uk/individuals/income/sa/foreign?matchId=d668b22f-d6b2-4072-8c48-61d11799f538&fromTaxYear=2019-20&toTaxYear=2020-21&useCase=LAA-C1
+{
+  "_links": {
+    "self": {
+      "href": "/individuals/income/sa/foreign?matchId=d668b22f-d6b2-4072-8c48-61d11799f538&fromTaxYear=2019-20&toTaxYear=2020-21"
+    }
+  },
+  "selfAssessment": {
+    "taxReturns": [
+
+    ]
+  }
+}
+calling https://test-api.service.hmrc.gov.uk/individuals/income/sa/further-details?matchId=d668b22f-d6b2-4072-8c48-61d11799f538&fromTaxYear=2019-20&toTaxYear=2020-21&useCase=LAA-C1
+{
+  "_links": {
+    "self": {
+      "href": "/individuals/income/sa/further-details?matchId=d668b22f-d6b2-4072-8c48-61d11799f538&fromTaxYear=2019-20&toTaxYear=2020-21"
+    }
+  },
+  "selfAssessment": {
+    "taxReturns": [
+
+    ]
+  }
+}
+calling https://test-api.service.hmrc.gov.uk/individuals/income/sa/interests-and-dividends?matchId=d668b22f-d6b2-4072-8c48-61d11799f538&fromTaxYear=2019-20&toTaxYear=2020-21&useCase=LAA-C1
+calling https://test-api.service.hmrc.gov.uk/individuals/income/sa/interests-and-dividends?matchId=d668b22f-d6b2-4072-8c48-61d11799f538&fromTaxYear=2019-20&toTaxYear=2020-21&useCase=LAA-C1
+{
+  "_links": {
+    "self": {
+      "href": "/individuals/income/sa/interests-and-dividends?matchId=d668b22f-d6b2-4072-8c48-61d11799f538&fromTaxYear=2019-20&toTaxYear=2020-21"
+    }
+  },
+  "selfAssessment": {
+    "taxReturns": [
+
+    ]
+  }
+}
+calling https://test-api.service.hmrc.gov.uk/individuals/income/sa/other?matchId=d668b22f-d6b2-4072-8c48-61d11799f538&fromTaxYear=2019-20&toTaxYear=2020-21&useCase=LAA-C1
+{
+  "_links": {
+    "self": {
+      "href": "/individuals/income/sa/other?matchId=d668b22f-d6b2-4072-8c48-61d11799f538&fromTaxYear=2019-20&toTaxYear=2020-21"
+    }
+  },
+  "selfAssessment": {
+    "taxReturns": [
+
+    ]
+  }
+}
+calling https://test-api.service.hmrc.gov.uk/individuals/income/sa/summary?matchId=d668b22f-d6b2-4072-8c48-61d11799f538&fromTaxYear=2019-20&toTaxYear=2020-21&useCase=LAA-C1
+{
+  "_links": {
+    "self": {
+      "href": "/individuals/income/sa/summary?matchId=d668b22f-d6b2-4072-8c48-61d11799f538&fromTaxYear=2019-20&toTaxYear=2020-21"
+    }
+  },
+  "selfAssessment": {
+    "taxReturns": [
+
+    ]
+  }
+}
+calling https://test-api.service.hmrc.gov.uk/individuals/income/sa/trusts?matchId=d668b22f-d6b2-4072-8c48-61d11799f538&fromTaxYear=2019-20&toTaxYear=2020-21&useCase=LAA-C1
+{
+  "_links": {
+    "self": {
+      "href": "/individuals/income/sa/trusts?matchId=d668b22f-d6b2-4072-8c48-61d11799f538&fromTaxYear=2019-20&toTaxYear=2020-21"
+    }
+  },
+  "selfAssessment": {
+    "taxReturns": [
+
+    ]
+  }
+}
+calling https://test-api.service.hmrc.gov.uk/individuals/employments/?matchId=d668b22f-d6b2-4072-8c48-61d11799f538
+{
+  "_links": {
+    "paye": {
+      "href": "/individuals/employments/paye?matchId=d668b22f-d6b2-4072-8c48-61d11799f538{&fromDate,toDate}",
+      "title": "Get an individual's PAYE employment data"
+    },
+    "self": {
+      "href": "/individuals/employments/?matchId=d668b22f-d6b2-4072-8c48-61d11799f538"
+    }
+  }
+}
+calling https://test-api.service.hmrc.gov.uk/individuals/employments/paye?matchId=d668b22f-d6b2-4072-8c48-61d11799f538&fromDate=2020-12-01&toDate=2021-02-25
+{
+  "_links": {
+    "self": {
+      "href": "/individuals/employments/paye?matchId=d668b22f-d6b2-4072-8c48-61d11799f538&fromDate=2020-12-01&toDate=2021-02-25"
+    }
+  },
+  "employments": [
+
+  ]
+}


### PR DESCRIPTION
This allows a user to run a rails console and query the sandbox e.g. 
```ruby
ApplyGetTest.call(
  first_name: 'first', 
  last_name: 'name', 
  nino: 'QQ123456C', 
  dob: '1990-01-01', 
  start_date: '2021-01-01', 
  end_date: '2021-03-31'
)
```
and, providing the data has been pre-configured in the sandbox, it will return the expected values.
I hope to implement a smoke test based on this implementation, ultimately.

It is not currently covered by tests as it is stand-alone, and should eventually be absorbed into a smoke-test/proper implementation