### PR TITLE
Refactor ApplyGetTest

### DIFF
--- a/app/services/apply_get_test.rb
+++ b/app/services/apply_get_test.rb
@@ -20,30 +20,34 @@ class ApplyGetTest
     new(**args).call
   end
 
-  def call
-    @correlation_id = SecureRandom.uuid
-    @result = { data: [] }
-    user_match_id = request_match_id
-    data = request_endpoint(user_match_id)
-    next_links = extract_next_links(data)
-    loop_each next_links
-
-    Rails.logger.info JSON.pretty_generate(JSON.parse(@result.to_json))
-    Rails.logger.info 'done'
+  def call(correlation_id: SecureRandom.uuid)
+    @correlation_id = correlation_id
+    @result = { data: [{ correlation_id: @correlation_id }] }
+    data = request_and_extract_data(request_match_id)
+    process_next_steps(data)
     @result.to_json
   end
 
   private
 
+  def process_next_steps(data)
+    return if data.to_s.eql?('INTERNAL_SERVER_ERROR')
+
+    next_links = extract_next_links(data)
+    loop_each next_links if next_links.any?
+  end
+
+  def request_and_extract_data(uri)
+    parsed_uri = build_uri(uri)
+    data = request_endpoint(parsed_uri.for_calling)
+    extract_data_from(data, parsed_uri)
+    data
+  end
+
   def loop_each(array_of_urls)
     array_of_urls.each do |uri|
-      parsed_uri = build_uri(uri)
-      data = request_endpoint(parsed_uri.for_calling)
-      extract_data_from(data, parsed_uri)
-      next if data.to_s.eql?('INTERNAL_SERVER_ERROR')
-
-      next_links = extract_next_links(data)
-      loop_each next_links if next_links.any?
+      data = request_and_extract_data(uri)
+      process_next_steps(data)
     end
   end
 
@@ -56,12 +60,12 @@ class ApplyGetTest
   end
 
   def data_is_valid?(data)
-    data.is_a?(Array) && data.except('_links').keys.present?
+    (data.is_a?(Array) || data.is_a?(Hash)) && data.except('_links').keys.present?
   end
 
   def record_valid_data(data, parsed_uri)
-    key = [parsed_uri.for_displaying, data.except('_links').keys.first].join('/').tr('-', '_')
-    value = data[data.except('_links').keys.first].first
+    key = build_data_key(data, parsed_uri)
+    value = build_data_value(data)
     @result[:data] << { "#{key}": value }
   end
 
@@ -69,8 +73,20 @@ class ApplyGetTest
     @result[:data] << { "#{parsed_uri.for_displaying}": 'returned INTERNAL_SERVER_ERROR' }
   end
 
+  def build_data_value(data)
+    if data.is_a?(Hash)
+      data[data.except('_links').keys.first]
+    else
+      data[data.except('_links').keys.first].first
+    end
+  end
+
+  def build_data_key(data, parsed_uri)
+    [parsed_uri.for_displaying, data.except('_links').keys.first].join('/').tr('-', '_')
+  end
+
   def request_endpoint(uri)
-    response = RestClient.get("#{host}#{uri}", Endpoint::Headers.call(uri, @correlation_id, @token))
+    response = RestClient.get("#{host}#{uri}", Endpoint::Headers.call(uri, @correlation_id, @use_case.bearer_token))
     JSON.parse(response)
   rescue RestClient::TooManyRequests
     Rails.logger.info "Rate limited while calling #{uri}: waiting then trying again"
@@ -87,12 +103,7 @@ class ApplyGetTest
   end
 
   def request_payload
-    {
-      firstName: data.first_name,
-      lastName: data.last_name,
-      nino: data.nino,
-      dateOfBirth: data.dob
-    }.to_json
+    { firstName: data.first_name, lastName: data.last_name, nino: data.nino, dateOfBirth: data.dob }.to_json
   end
 
   def extract_next_links(data)
@@ -104,15 +115,11 @@ class ApplyGetTest
   end
 
   def build_headers(uri)
-    Endpoint::Headers.call(uri, @correlation_id, token)
+    Endpoint::Headers.call(uri, @correlation_id, @use_case.bearer_token)
   end
 
   def host
     @host ||= @use_case.host
-  end
-
-  def token
-    @token ||= @use_case.bearer_token
   end
 end
 # :nocov:


### PR DESCRIPTION
Allow the passing of a correlation_id for repeatable
outputs in smoke-tests
Reduce duplication and keep the length under 100 lines