### PR TITLE
Update smoke tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -323,7 +323,7 @@ workflows:
   smoke-test:
     triggers:
       - schedule:
-          cron: "30 8 * * 1-5" # 1-5 is Mon-Fri
+          cron: "30 8-16 * * 1-5" # 8-16 is 8am-4pm, 1-5 is Mon-Fri
           filters:
             branches:
               only: main

--- a/bin/smoke_tests
+++ b/bin/smoke_tests
@@ -1,5 +1,6 @@
 #!/bin/sh
-URL=$(sed 's#.* ##g' <<< $(kubectl get ingresses | grep -o -m4 "main-laa-.*uk" | head -n1))
+INGRESS=$(kubectl get ingresses | grep -o -m4 "main-laa-.*uk" | head -n1)
+URL=$(echo "$INGRESS" | sed 's#.* ##g')
 STATUS=$(curl -s -o /dev/null -w '%{http_code}' "https://$URL/smoke-test")
 if [ $STATUS -eq 200 ]; then
   exit 0;


### PR DESCRIPTION
Update the smoke test script as the <<< command is unavailable in `sh` I have separated the
ingress generation into a newline to make it easier to comprehend and then pipe into sed

Then update circle CI cron job to run the smoke test every hour from 8-4 on the half hour
this should let us debug the smoke test script until it works
then the cron job can go back to daily