### PR TITLE
Simplify smoke tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ orbs:
 executors:
   basic-executor:
     docker:
-      - image: cimg/base:2020.01
+      - image: cimg/base:2021.04
   cloud-platform-executor:
     docker:
       - image: ministryofjustice/cloud-platform-tools:1.41
@@ -145,7 +145,7 @@ jobs:
       - store_artifacts:
           path: ./coverage
   smoke_tests:
-    executor: cloud-platform-executor
+    executor: basic-executor
     steps:
       - checkout
       - setup_remote_docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -150,8 +150,6 @@ jobs:
       - checkout
       - setup_remote_docker:
           docker_layer_caching: true
-      - *decrypt_secrets
-      - *authenticate_k8s
       - run:
           name: Run smoke test script
           command: ./bin/smoke_tests

--- a/bin/smoke_tests
+++ b/bin/smoke_tests
@@ -1,7 +1,5 @@
 #!/bin/sh
-INGRESS=$(kubectl get ingresses | grep -o -m4 "main-laa-.*uk" | head -n1)
-URL=$(echo "$INGRESS" | sed 's#.* ##g')
-STATUS=$(curl -s -o /dev/null -w '%{http_code}' "https://$URL/smoke-test")
+STATUS=$(curl -s -o /dev/null -w '%{http_code}' "https://$SMOKE_TEST_URI/smoke-test")
 if [ $STATUS -eq 200 ]; then
   exit 0;
 else


### PR DESCRIPTION
Speed up the process of running the smoke tests by running on a smaller image
The job is only executing a curl command seeing if it returns 200, the logic
is executed on a host machine that is now stored in an env_var in circle, so we don't
need the overhead of pulling down the cp docker image, decrypting secrets and 
configuring K8s