### PR TITLE
Bugfix: Reduce the sentry sample rate

### DIFF
--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -5,10 +5,8 @@ Sentry.init do |config|
   config.excluded_exceptions += %w[
     TestWorker::SentryIgnoresThisSidekiqFailError
   ]
-  # Set tracesSampleRate to 1.0 to capture 100%
-  # of transactions for performance monitoring.
-  # We recommend adjusting this value in production
-  config.traces_sample_rate = 0.5
+  # Send 5% of transactions for performance monitoring
+  config.traces_sample_rate = 0.05
   # or
   # config.traces_sampler = lambda do |_context|
   #   true


### PR DESCRIPTION
This is shared between all applications in the namespace
and should not be so high