### PR TITLE
ap-2482: Create submission_process_worker class with perform method

### DIFF
--- a/app/controllers/api/V1/use_case_controller.rb
+++ b/app/controllers/api/V1/use_case_controller.rb
@@ -4,6 +4,7 @@ module Api
       def submit
         submission = Submission.new(filtered_params.merge(status: 'created'))
         if submission.save
+          SubmissionProcessWorker.perform_async(filtered_params.merge(status: 'created'))
           render json: { id: submission.id, _links: [href: "#{request.base_url}/submission-status/#{submission.id}"] },
                  status: :accepted
         else

--- a/app/controllers/api/V1/use_case_controller.rb
+++ b/app/controllers/api/V1/use_case_controller.rb
@@ -4,7 +4,7 @@ module Api
       def submit
         submission = Submission.new(filtered_params.merge(status: 'created'))
         if submission.save
-          SubmissionProcessWorker.perform_async(filtered_params.merge(status: 'created'))
+          SubmissionProcessWorker.perform_async(submission.id)
           render json: { id: submission.id, _links: [href: "#{request.base_url}/submission-status/#{submission.id}"] },
                  status: :accepted
         else

--- a/app/models/concerns/submission_processable.rb
+++ b/app/models/concerns/submission_processable.rb
@@ -72,7 +72,7 @@ module SubmissionProcessable
     request_endpoint(uri)
     # :nocov:
   rescue RestClient::InternalServerError, RestClient::NotFound
-    'INTERNAL_SERVER_ERROR' # improve this, hard to do currently as only the live service fails
+    'INTERNAL_SERVER_ERROR' # TODO: improve this, hard to do currently as only the live service fails
   end
 
   def request_match_id

--- a/app/models/concerns/submission_processable.rb
+++ b/app/models/concerns/submission_processable.rb
@@ -1,0 +1,101 @@
+module SubmissionProcessable
+  extend ActiveSupport::Concern
+
+  private
+
+  def process_next_steps(data)
+    return if data.to_s.eql?('INTERNAL_SERVER_ERROR')
+
+    next_links = extract_next_links(data)
+    loop_each next_links if next_links.any?
+  end
+
+  def request_and_extract_data(uri)
+    parsed_uri = build_uri(uri)
+    data = request_endpoint(parsed_uri.for_calling)
+    extract_data_from(data, parsed_uri)
+    data
+  end
+
+  def loop_each(array_of_urls)
+    array_of_urls.each do |uri|
+      data = request_and_extract_data(uri)
+      process_next_steps(data)
+    end
+  end
+
+  def extract_data_from(data, parsed_uri)
+    if data.to_s.eql?('INTERNAL_SERVER_ERROR')
+      record_error_data(parsed_uri)
+    elsif data_is_valid?(data)
+      record_valid_data(data, parsed_uri)
+    end
+  end
+
+  def data_is_valid?(data)
+    (data.is_a?(Array) || data.is_a?(Hash)) && data.except('_links').keys.present?
+  end
+
+  def record_valid_data(data, parsed_uri)
+    key = build_data_key(data, parsed_uri)
+    value = build_data_value(data)
+    @result[:data] << { "#{key}": value }
+  end
+
+  def record_error_data(parsed_uri)
+    @result[:data] << { "#{parsed_uri.for_displaying}": 'returned INTERNAL_SERVER_ERROR' }
+  end
+
+  def build_data_value(data)
+    if data.is_a?(Hash)
+      data[data.except('_links').keys.first]
+    else
+      # :nocov:
+      data[data.except('_links').keys.first].first
+      # :nocov:
+    end
+  end
+
+  def build_data_key(data, parsed_uri)
+    [parsed_uri.for_displaying, data.except('_links').keys.first].join('/').tr('-', '_')
+  end
+
+  def request_endpoint(uri)
+    response = RestClient.get("#{host}#{uri}", Endpoint::Headers.call(uri, @correlation_id, @use_case.bearer_token))
+    JSON.parse(response)
+  rescue RestClient::TooManyRequests
+    # :nocov:
+    Rails.logger.info "Rate limited while calling #{uri}: waiting then trying again"
+    sleep(0.33)
+    request_endpoint(uri)
+    # :nocov:
+  rescue RestClient::InternalServerError, RestClient::NotFound
+    'INTERNAL_SERVER_ERROR' # improve this, hard to do currently as only the live service fails
+  end
+
+  def request_match_id
+    uri = '/individuals/matching'
+    response = RestClient.post("#{host}#{uri}", request_payload, build_headers(uri))
+    JSON.parse(response, object_class: OpenStruct)._links.individual.href
+  end
+
+  def request_payload
+    { firstName: data.first_name, lastName: data.last_name, nino: data.nino, dateOfBirth: data.dob }.to_json
+  end
+
+  def extract_next_links(data)
+    data['_links'].filter_map { |x| x[1]['href'] unless x[0].eql?('self') }
+  end
+
+  def build_uri(uri)
+    Endpoint::Uri.new(uri, use_case: @use_case.use_case, from_date: data.start_date, to_date: data.end_date)
+  end
+
+  def build_headers(uri)
+    Endpoint::Headers.call(uri, @correlation_id, @use_case.bearer_token)
+  end
+
+  def host
+    @host ||= @use_case.host
+  end
+end

--- a/app/models/concerns/submission_processable.rb
+++ b/app/models/concerns/submission_processable.rb
@@ -51,6 +51,8 @@ module SubmissionProcessable
       data[data.except('_links').keys.first]
     else
       # :nocov:
+      # is this required? (it doesn't seem to be getting called,
+      # I am not sure what sort of data structure it would apply to?)
       data[data.except('_links').keys.first].first
       # :nocov:
     end

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -1,10 +1,118 @@
 class Submission < ApplicationRecord
   has_one_attached :result
+  attr_reader :data
 
   USE_CASES = %w[one two three four].freeze
   validates :use_case, presence: true, inclusion: { in: USE_CASES, message: 'Invalid use case' }
 
   def as_json(*)
     super.except('id', 'status', 'created_at', 'updated_at')
+  end
+
+  def process!
+    @correlation_id = id
+    @use_case = UseCase.new(use_case.to_sym)
+    @data = OpenStruct.new(as_json.except('use_case'))
+    @result = { data: [{ correlation_id: @correlation_id }] }
+    data = request_and_extract_data(request_match_id)
+    process_next_steps(data)
+    result.attach(io: StringIO.new(@result.to_json),
+                  filename: "#{id}.json",
+                  content_type: 'application/json',
+                  key: "submission/result/#{id}")
+  end
+
+  private
+
+  def process_next_steps(data)
+    return if data.to_s.eql?('INTERNAL_SERVER_ERROR')
+
+    next_links = extract_next_links(data)
+    loop_each next_links if next_links.any?
+  end
+
+  def request_and_extract_data(uri)
+    parsed_uri = build_uri(uri)
+    data = request_endpoint(parsed_uri.for_calling)
+    extract_data_from(data, parsed_uri)
+    data
+  end
+
+  def loop_each(array_of_urls)
+    array_of_urls.each do |uri|
+      data = request_and_extract_data(uri)
+      process_next_steps(data)
+    end
+  end
+
+  def extract_data_from(data, parsed_uri)
+    if data.to_s.eql?('INTERNAL_SERVER_ERROR')
+      record_error_data(parsed_uri)
+    elsif data_is_valid?(data)
+      record_valid_data(data, parsed_uri)
+    end
+  end
+
+  def data_is_valid?(data)
+    (data.is_a?(Array) || data.is_a?(Hash)) && data.except('_links').keys.present?
+  end
+
+  def record_valid_data(data, parsed_uri)
+    key = build_data_key(data, parsed_uri)
+    value = build_data_value(data)
+    @result[:data] << { "#{key}": value }
+  end
+
+  def record_error_data(parsed_uri)
+    @result[:data] << { "#{parsed_uri.for_displaying}": 'returned INTERNAL_SERVER_ERROR' }
+  end
+
+  def build_data_value(data)
+    if data.is_a?(Hash)
+      data[data.except('_links').keys.first]
+    else
+      data[data.except('_links').keys.first].first
+    end
+  end
+
+  def build_data_key(data, parsed_uri)
+    [parsed_uri.for_displaying, data.except('_links').keys.first].join('/').tr('-', '_')
+  end
+
+  def request_endpoint(uri)
+    response = RestClient.get("#{host}#{uri}", Endpoint::Headers.call(uri, @correlation_id, @use_case.bearer_token))
+    JSON.parse(response)
+  rescue RestClient::TooManyRequests
+    Rails.logger.info "Rate limited while calling #{uri}: waiting then trying again"
+    sleep(0.33)
+    request_endpoint(uri)
+  rescue RestClient::InternalServerError, RestClient::NotFound
+    'INTERNAL_SERVER_ERROR' # improve this, hard to do currently as only the live service fails
+  end
+
+  def request_match_id
+    uri = '/individuals/matching'
+    response = RestClient.post("#{host}#{uri}", request_payload, build_headers(uri))
+    JSON.parse(response, object_class: OpenStruct)._links.individual.href
+  end
+
+  def request_payload
+    { firstName: data.first_name, lastName: data.last_name, nino: data.nino, dateOfBirth: data.dob }.to_json
+  end
+
+  def extract_next_links(data)
+    data['_links'].filter_map { |x| x[1]['href'] unless x[0].eql?('self') }
+  end
+
+  def build_uri(uri)
+    Endpoint::Uri.new(uri, use_case: @use_case.use_case, from_date: data.start_date, to_date: data.end_date)
+  end
+
+  def build_headers(uri)
+    Endpoint::Headers.call(uri, @correlation_id, @use_case.bearer_token)
+  end
+
+  def host
+    @host ||= @use_case.host
   end
 end

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -9,6 +9,8 @@ class Submission < ApplicationRecord
     super.except('id', 'status', 'created_at', 'updated_at')
   end
 
+  include SubmissionProcessable
+
   def process!
     @correlation_id = id
     @use_case = UseCase.new(use_case.to_sym)
@@ -20,99 +22,5 @@ class Submission < ApplicationRecord
                   filename: "#{id}.json",
                   content_type: 'application/json',
                   key: "submission/result/#{id}")
-  end
-
-  private
-
-  def process_next_steps(data)
-    return if data.to_s.eql?('INTERNAL_SERVER_ERROR')
-
-    next_links = extract_next_links(data)
-    loop_each next_links if next_links.any?
-  end
-
-  def request_and_extract_data(uri)
-    parsed_uri = build_uri(uri)
-    data = request_endpoint(parsed_uri.for_calling)
-    extract_data_from(data, parsed_uri)
-    data
-  end
-
-  def loop_each(array_of_urls)
-    array_of_urls.each do |uri|
-      data = request_and_extract_data(uri)
-      process_next_steps(data)
-    end
-  end
-
-  def extract_data_from(data, parsed_uri)
-    if data.to_s.eql?('INTERNAL_SERVER_ERROR')
-      record_error_data(parsed_uri)
-    elsif data_is_valid?(data)
-      record_valid_data(data, parsed_uri)
-    end
-  end
-
-  def data_is_valid?(data)
-    (data.is_a?(Array) || data.is_a?(Hash)) && data.except('_links').keys.present?
-  end
-
-  def record_valid_data(data, parsed_uri)
-    key = build_data_key(data, parsed_uri)
-    value = build_data_value(data)
-    @result[:data] << { "#{key}": value }
-  end
-
-  def record_error_data(parsed_uri)
-    @result[:data] << { "#{parsed_uri.for_displaying}": 'returned INTERNAL_SERVER_ERROR' }
-  end
-
-  def build_data_value(data)
-    if data.is_a?(Hash)
-      data[data.except('_links').keys.first]
-    else
-      data[data.except('_links').keys.first].first
-    end
-  end
-
-  def build_data_key(data, parsed_uri)
-    [parsed_uri.for_displaying, data.except('_links').keys.first].join('/').tr('-', '_')
-  end
-
-  def request_endpoint(uri)
-    response = RestClient.get("#{host}#{uri}", Endpoint::Headers.call(uri, @correlation_id, @use_case.bearer_token))
-    JSON.parse(response)
-  rescue RestClient::TooManyRequests
-    Rails.logger.info "Rate limited while calling #{uri}: waiting then trying again"
-    sleep(0.33)
-    request_endpoint(uri)
-  rescue RestClient::InternalServerError, RestClient::NotFound
-    'INTERNAL_SERVER_ERROR' # improve this, hard to do currently as only the live service fails
-  end
-
-  def request_match_id
-    uri = '/individuals/matching'
-    response = RestClient.post("#{host}#{uri}", request_payload, build_headers(uri))
-    JSON.parse(response, object_class: OpenStruct)._links.individual.href
-  end
-
-  def request_payload
-    { firstName: data.first_name, lastName: data.last_name, nino: data.nino, dateOfBirth: data.dob }.to_json
-  end
-
-  def extract_next_links(data)
-    data['_links'].filter_map { |x| x[1]['href'] unless x[0].eql?('self') }
-  end
-
-  def build_uri(uri)
-    Endpoint::Uri.new(uri, use_case: @use_case.use_case, from_date: data.start_date, to_date: data.end_date)
-  end
-
-  def build_headers(uri)
-    Endpoint::Headers.call(uri, @correlation_id, @use_case.bearer_token)
-  end
-
-  def host
-    @host ||= @use_case.host
   end
 end

--- a/app/services/apply_get_test.rb
+++ b/app/services/apply_get_test.rb
@@ -2,6 +2,8 @@
 class ApplyGetTest
   attr_reader :data
 
+  include SubmissionProcessable
+
   def initialize(use_case, **args)
     return unless args.keys.difference(%i[first_name last_name nino dob start_date end_date]).empty?
 
@@ -32,100 +34,6 @@ class ApplyGetTest
     data = request_and_extract_data(request_match_id)
     process_next_steps(data)
     @result.to_json
-  end
-
-  private
-
-  def process_next_steps(data)
-    return if data.to_s.eql?('INTERNAL_SERVER_ERROR')
-
-    next_links = extract_next_links(data)
-    loop_each next_links if next_links.any?
-  end
-
-  def request_and_extract_data(uri)
-    parsed_uri = build_uri(uri)
-    data = request_endpoint(parsed_uri.for_calling)
-    extract_data_from(data, parsed_uri)
-    data
-  end
-
-  def loop_each(array_of_urls)
-    array_of_urls.each do |uri|
-      data = request_and_extract_data(uri)
-      process_next_steps(data)
-    end
-  end
-
-  def extract_data_from(data, parsed_uri)
-    if data.to_s.eql?('INTERNAL_SERVER_ERROR')
-      record_error_data(parsed_uri)
-    elsif data_is_valid?(data)
-      record_valid_data(data, parsed_uri)
-    end
-  end
-
-  def data_is_valid?(data)
-    (data.is_a?(Array) || data.is_a?(Hash)) && data.except('_links').keys.present?
-  end
-
-  def record_valid_data(data, parsed_uri)
-    key = build_data_key(data, parsed_uri)
-    value = build_data_value(data)
-    @result[:data] << { "#{key}": value }
-  end
-
-  def record_error_data(parsed_uri)
-    @result[:data] << { "#{parsed_uri.for_displaying}": 'returned INTERNAL_SERVER_ERROR' }
-  end
-
-  def build_data_value(data)
-    if data.is_a?(Hash)
-      data[data.except('_links').keys.first]
-    else
-      data[data.except('_links').keys.first].first
-    end
-  end
-
-  def build_data_key(data, parsed_uri)
-    [parsed_uri.for_displaying, data.except('_links').keys.first].join('/').tr('-', '_')
-  end
-
-  def request_endpoint(uri)
-    response = RestClient.get("#{host}#{uri}", Endpoint::Headers.call(uri, @correlation_id, @use_case.bearer_token))
-    JSON.parse(response)
-  rescue RestClient::TooManyRequests
-    Rails.logger.info "Rate limited while calling #{uri}: waiting then trying again"
-    sleep(0.33)
-    request_endpoint(uri)
-  rescue RestClient::InternalServerError, RestClient::NotFound
-    'INTERNAL_SERVER_ERROR' # improve this, hard to do currently as only the live service fails
-  end
-
-  def request_match_id
-    uri = '/individuals/matching'
-    response = RestClient.post("#{host}#{uri}", request_payload, build_headers(uri))
-    JSON.parse(response, object_class: OpenStruct)._links.individual.href
-  end
-
-  def request_payload
-    { firstName: data.first_name, lastName: data.last_name, nino: data.nino, dateOfBirth: data.dob }.to_json
-  end
-
-  def extract_next_links(data)
-    data['_links'].filter_map { |x| x[1]['href'] unless x[0].eql?('self') }
-  end
-
-  def build_uri(uri)
-    Endpoint::Uri.new(uri, use_case: @use_case.use_case, from_date: data.start_date, to_date: data.end_date)
-  end
-
-  def build_headers(uri)
-    Endpoint::Headers.call(uri, @correlation_id, @use_case.bearer_token)
-  end
-
-  def host
-    @host ||= @use_case.host
   end
 end
 # :nocov:

--- a/app/workers/submission_process_worker.rb
+++ b/app/workers/submission_process_worker.rb
@@ -1,0 +1,20 @@
+class SubmissionProcessWorker
+  include Sidekiq::Worker
+  attr_accessor :retry_count
+
+  MAX_RETRIES = 3
+  sidekiq_options queue: 'submissions', retry: MAX_RETRIES
+
+  def perform(submission_id)
+    submission = Submission.find(submission_id)
+
+    if @retry_count.to_i >= MAX_RETRIES
+      submission.update!(status: 'failed')
+      Sentry.capture_message("Retry attempts exhauasted for submission: #{submission.id}")
+      return
+    end
+
+    submission.process!
+    submission.update!(status: 'completed')
+  end
+end

--- a/app/workers/submission_process_worker.rb
+++ b/app/workers/submission_process_worker.rb
@@ -15,6 +15,6 @@ class SubmissionProcessWorker
     end
 
     submission.process!
-    submission.update!(status: 'completed')
+    submission.update!(status: 'processed')
   end
 end

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -2,3 +2,4 @@
 :queues:
   - default
   - tasks
+  - submissions

--- a/spec/models/submission_spec.rb
+++ b/spec/models/submission_spec.rb
@@ -2,18 +2,18 @@
 
 require 'rails_helper'
 
-RSpec.describe Submission, type: :model do
-  subject(:submission) { described_class.new(params) }
+RSpec.describe Submission, type: :model, vcr: { cassette_name: 'use_case_one_success' } do
+  subject(:submission) { described_class.create(params) }
 
   let(:params) do
     {
       use_case: 'one',
-      first_name: 'Bob',
-      last_name: 'Smith',
-      nino: 'XX123456Y',
-      dob: '1990-01-01',
-      start_date: '2021-01-01',
-      end_date: '2021-03-31'
+      first_name: 'Langley',
+      last_name: 'Yorke',
+      nino: 'MN212451D',
+      dob: '1992-07-22',
+      start_date: '2020-08-01',
+      end_date: '2020-10-01'
     }
   end
 
@@ -30,6 +30,47 @@ RSpec.describe Submission, type: :model do
 
     it 'does not include standard model values' do
       expect(as_json.keys).to_not include %w[id status created_at updated_at]
+    end
+  end
+
+  describe '#process!' do
+    subject(:process!) { submission.process! }
+
+    before do
+      remove_request_stub(@hmrc_stub_requests)
+      allow(REDIS).to receive(:get).with('use_case_one_bearer_token').and_return('dummy_bearer_token')
+    end
+
+    it 'adds a result attachment to the submission' do
+      expect do
+        subject
+      end.to change(ActiveStorage::Attachment, :count).by(1)
+    end
+
+    it 'gives the result attachment the a filename' do
+      subject
+      expect(submission.result.filename).to eq "#{submission.id}.json"
+    end
+
+    it 'gives the result attachment a key' do
+      subject
+      expect(submission.result.key).to eq "submission/result/#{submission.id}"
+    end
+
+    it 'gives the result attachment a content type' do
+      subject
+      expect(submission.result.content_type).to eq 'application/json'
+    end
+
+    context 'RestClient::InternalServerError' do
+      before do
+        allow(RestClient).to receive(:get).with(any_args).and_raise(RestClient::InternalServerError)
+      end
+
+      it 'adds a result attachment detailing the error' do
+        subject
+        expect(submission.result.blob.download).to match(/returned INTERNAL_SERVER_ERROR/)
+      end
     end
   end
 end

--- a/spec/workers/submission_process_worker_spec.rb
+++ b/spec/workers/submission_process_worker_spec.rb
@@ -1,0 +1,41 @@
+require 'rails_helper'
+
+RSpec.describe SubmissionProcessWorker do
+  let(:worker) { described_class.new }
+  let!(:submission) { create :submission }
+
+  subject { worker.perform(submission.id) }
+
+  before do
+    allow(Submission).to receive(:find).with(submission.id).and_return(submission)
+    allow(submission).to receive(:process!).and_return(true)
+  end
+
+  describe '.perform' do
+    it 'calls process! on the submission' do
+      expect(submission).to receive(:process!)
+      subject
+    end
+
+    it 'updates the submission status' do
+      subject
+      expect(submission.status).to eq('completed')
+    end
+
+    context 'when the retry is exceeding the max retries' do
+      before do
+        worker.retry_count = 4
+      end
+
+      it 'sends a sentry alert' do
+        expect(Sentry).to receive(:capture_message).with(/^Retry attempts exhauasted for submission: #{submission.id}/)
+        subject
+      end
+
+      it 'updates the submission status' do
+        subject
+        expect(submission.status).to eq('failed')
+      end
+    end
+  end
+end

--- a/spec/workers/submission_process_worker_spec.rb
+++ b/spec/workers/submission_process_worker_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe SubmissionProcessWorker do
 
     it 'updates the submission status' do
       subject
-      expect(submission.status).to eq('completed')
+      expect(submission.status).to eq('processed')
     end
 
     context 'when the retry is exceeding the max retries' do


### PR DESCRIPTION
**What**
Refactor HMRC calls into sidekiq job.
https://dsdmoj.atlassian.net/browse/AP-2482

**Why**
So that they can be backgrounded and monitored via the sidekiq console

**How**
Created submission_process_worker sidekiq worker job
Call this job with .perform_async in use_case_controller.submit
Created a concern submission_processable for code shared between the submission and apply_get test classes, moved the existing private methods from apply_get_test to this module
First stab at testing the sidekiq job 
(Currently the private methods in submission_processable are tested by calling the public process! method in submission, however, there are four lines in submission_processable that currently have no test coverage, marked :nocov. Lines 70-72 I was unable to test without entering an endless loop. Possibly this code should be refactored as part of a general ticket about handing error conditions - see comment on line 75. Line 56 doesn't seem to be getting called and I couldn't work out what sort of data structure it would apply to?)