### PR TITLE
AP-2492 Add submission-status GET endpoint

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,6 +22,8 @@ gem 'sidekiq'
 
 group :development, :test do
   gem 'byebug'
+  gem 'factory_bot_rails', '>= 5.2.0'
+  gem 'faker', '>=1.9.1'
   gem 'guard-livereload'
   gem 'guard-rspec'
   gem 'guard-rubocop'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -140,6 +140,13 @@ GEM
       http_parser.rb (~> 0.6.0)
     erubi (1.10.0)
     eventmachine (1.2.7)
+    factory_bot (6.2.0)
+      activesupport (>= 5.0.0)
+    factory_bot_rails (6.2.0)
+      factory_bot (~> 6.2.0)
+      railties (>= 5.0.0)
+    faker (2.19.0)
+      i18n (>= 1.6, < 2)
     faraday (1.7.1)
       faraday-em_http (~> 1.0)
       faraday-em_synchrony (~> 1.0)
@@ -404,6 +411,8 @@ DEPENDENCIES
   byebug
   config
   dotenv-rails
+  factory_bot_rails (>= 5.2.0)
+  faker (>= 1.9.1)
   guard-livereload
   guard-rspec
   guard-rubocop

--- a/app/controllers/api/V1/use_case_controller.rb
+++ b/app/controllers/api/V1/use_case_controller.rb
@@ -4,7 +4,8 @@ module Api
       def submit
         submission = Submission.new(filtered_params.merge(status: 'created'))
         if submission.save
-          render json: { id: submission.id }, status: :accepted
+          render json: { id: submission.id, _links: [href: "#{request.base_url}/submission-status/#{submission.id}"] },
+                 status: :accepted
         else
           render json: submission.errors&.to_json, status: :bad_request
         end

--- a/app/controllers/submission_status_controller.rb
+++ b/app/controllers/submission_status_controller.rb
@@ -1,0 +1,10 @@
+class SubmissionStatusController < ApplicationController
+  def show
+    submission = Submission.find(params.fetch(:id))
+    render json: { submission: submission.id,
+                   status: submission.status,
+                   _links: [href: "#{request.base_url}/submission-status/#{submission.id}"] }
+  rescue ActiveRecord::RecordNotFound
+    render status: :not_found
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -37,6 +37,8 @@ Rails.application.routes.draw do
       get 'use_case/four', to: 'use_case#four', format: :json
     end
   end
+
+  get 'submission-status/:id', to: 'submission_status#show', as: 'submission-status-id', format: :json
 end
 
 def secure_compare(passed, stored)

--- a/spec/factories/submission_factory.rb
+++ b/spec/factories/submission_factory.rb
@@ -1,0 +1,19 @@
+NINO_REGEXP = /^[A-CEGHJ-PR-TW-Z]{1}[A-CEGHJ-NPR-TW-Z]{1}[0-9]{6}[A-DFM]{1}$/
+
+FactoryBot.define do
+  factory :submission do
+    id { SecureRandom.uuid }
+    status { :created }
+    use_case { %i[one two three four].sample }
+    first_name { Faker::Name.first_name }
+    last_name { Faker::Name.last_name }
+    nino { Faker::Base.regexify(NINO_REGEXP) }
+    dob { Faker::Date.birthday }
+    start_date { Faker::Date.backward(days: 180) }
+    end_date { start_date + 3.months }
+  end
+
+  trait :in_progress do
+    status { :in_progress }
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -68,4 +68,7 @@ RSpec.configure do |config|
       with.library :rails
     end
   end
+
+  # remove the need to prefix every create or build with FactoryBot
+  config.include FactoryBot::Syntax::Methods
 end

--- a/spec/requests/api/v1/use_case_swagger_spec.rb
+++ b/spec/requests/api/v1/use_case_swagger_spec.rb
@@ -47,6 +47,8 @@ RSpec.describe 'api/v1/use_case', type: :request, swagger_doc: 'v1/swagger.yaml'
         run_test! do |response|
           expect(response.media_type).to eq('application/json')
           expect(response.body).to match(/id/)
+          expect(response.body).to match(/_links/)
+          expect(JSON.parse(response.body)['_links'].first['href']).to match(%r{http://www.example.com/submission-status/})
         end
       end
 

--- a/spec/requests/submission_status_controller_spec.rb
+++ b/spec/requests/submission_status_controller_spec.rb
@@ -2,22 +2,8 @@ require 'rails_helper'
 
 RSpec.describe SubmissionStatusController, type: :request do
   describe 'GET /submission-status/:id' do
-    let(:params) do
-      {
-        use_case: 'one',
-        first_name: 'Bob',
-        last_name: 'Smith',
-        nino: 'XX123456Y',
-        dob: '1990-01-01',
-        start_date: '2021-01-01',
-        end_date: '2021-03-31'
-      }
-    end
-    let(:submission) { Submission.new(params) }
-
+    let(:submission) { create :submission, :in_progress }
     before do
-      submission.status = 'in_progress'
-      submission.save!
       get submission_status_id_path(id)
     end
 

--- a/spec/requests/submission_status_controller_spec.rb
+++ b/spec/requests/submission_status_controller_spec.rb
@@ -1,0 +1,51 @@
+require 'rails_helper'
+
+RSpec.describe SubmissionStatusController, type: :request do
+  describe 'GET /submission-status/:id' do
+    let(:params) do
+      {
+        use_case: 'one',
+        first_name: 'Bob',
+        last_name: 'Smith',
+        nino: 'XX123456Y',
+        dob: '1990-01-01',
+        start_date: '2021-01-01',
+        end_date: '2021-03-31'
+      }
+    end
+    let(:submission) { Submission.new(params) }
+
+    before do
+      submission.status = 'in_progress'
+      submission.save!
+      get submission_status_id_path(id)
+    end
+
+    context 'with the submission id of an existent submission' do
+      let(:id) { submission.id }
+      let(:expected_response) do
+        {
+          submission: id,
+          status: 'in_progress',
+          _links: [
+            href: "http://www.example.com/submission-status/#{id}"
+          ]
+        }
+      end
+      it 'returns success' do
+        expect(response).to have_http_status(:success)
+      end
+
+      it 'returns the expected response' do
+        expect(JSON.parse(response.body, symbolize_names: true)).to eq(expected_response)
+      end
+    end
+
+    context 'with the submission id of a non-existent submission' do
+      let(:id) { '1234' }
+      it 'returns a 404 error' do
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+  end
+end


### PR DESCRIPTION
https://dsdmoj.atlassian.net/browse/AP-2492

Adds a new endpoint `/submission-status` which accepts the id of a submission and returns the status of that submission, along with a link to itself to allow further requests to be made.

Also amends the existing submission POST endpoint so that it returns a link to the status endpoint in its response.

