### PR TITLE
AP-2493 GET Submission endpoint

### DIFF
--- a/app/controllers/api/V1/submission_controller.rb
+++ b/app/controllers/api/V1/submission_controller.rb
@@ -1,0 +1,31 @@
+module Api
+  module V1
+    class SubmissionController < ApiController
+      def show
+        render status: :accepted unless submission.status.eql? 'completed'
+        render status: :internal_server_error if completed_but_no_attachment?
+        render json: attachment.blob.download if completed_with_attachment?
+      rescue ActiveRecord::RecordNotFound
+        render status: :not_found
+      end
+
+      private
+
+      def submission
+        @submission ||= Submission.find(params.fetch(:id))
+      end
+
+      def attachment
+        @attachment ||= submission.result.attachment
+      end
+
+      def completed_with_attachment?
+        submission.status.eql?('completed') && attachment.present?
+      end
+
+      def completed_but_no_attachment?
+        submission.status.eql?('completed') && attachment.nil?
+      end
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -37,6 +37,7 @@ Rails.application.routes.draw do
       get 'use_case/three', to: 'use_case#three', format: :json
       get 'use_case/four', to: 'use_case#four', format: :json
       get 'submission-status/:id', to: 'submission_status#show', as: 'submission-status-id', format: :json
+      get 'submission/:id', to: 'submission#show', as: 'submission-id', format: :json
     end
   end
 end

--- a/db/migrate/20210916154020_change_active_storage_ids_to_uuid.rb
+++ b/db/migrate/20210916154020_change_active_storage_ids_to_uuid.rb
@@ -1,0 +1,67 @@
+class ChangeActiveStorageIdsToUuid < ActiveRecord::Migration[6.1]
+  def change
+    drop_table :active_storage_attachments do |t|
+      t.string     :name,     null: false
+      t.references :record,   null: false, polymorphic: true, index: false
+      t.references :blob,     null: false
+
+      t.datetime :created_at, null: false
+
+      t.index [ :record_type, :record_id, :name, :blob_id ], name: "index_active_storage_attachments_uniqueness", unique: true
+      t.foreign_key :active_storage_blobs, column: :blob_id
+    end
+
+    drop_table :active_storage_variant_records do |t|
+      t.belongs_to :blob, null: false, index: false
+      t.string :variation_digest, null: false
+
+      t.index %i[ blob_id variation_digest ], name: "index_active_storage_variant_records_uniqueness", unique: true
+      t.foreign_key :active_storage_blobs, column: :blob_id
+    end
+
+    drop_table :active_storage_blobs do |t|
+      t.string   :key,          null: false
+      t.string   :filename,     null: false
+      t.string   :content_type
+      t.text     :metadata
+      t.string   :service_name, null: false
+      t.bigint   :byte_size,    null: false
+      t.string   :checksum,     null: false
+      t.datetime :created_at,   null: false
+
+      t.index [ :key ], unique: true
+    end
+
+    create_table :active_storage_blobs, id: :uuid do |t|
+      t.string   :key,          null: false
+      t.string   :filename,     null: false
+      t.string   :content_type
+      t.text     :metadata
+      t.string   :service_name, null: false
+      t.bigint   :byte_size,    null: false
+      t.string   :checksum,     null: false
+      t.datetime :created_at,   null: false
+
+      t.index [ :key ], unique: true
+    end
+
+    create_table :active_storage_attachments, id: :uuid do |t|
+      t.string     :name,     null: false
+      t.references :record,   null: false, polymorphic: true, index: false, type: :uuid
+      t.references :blob,     null: false, type: :uuid
+
+      t.datetime :created_at, null: false
+
+      t.index [ :record_type, :record_id, :name, :blob_id ], name: "index_active_storage_attachments_uniqueness", unique: true
+      t.foreign_key :active_storage_blobs, column: :blob_id
+    end
+
+    create_table :active_storage_variant_records, id: :uuid do |t|
+      t.belongs_to :blob, null: false, index: false, type: :uuid
+      t.string :variation_digest, null: false
+
+      t.index %i[ blob_id variation_digest ], name: "index_active_storage_variant_records_uniqueness", unique: true
+      t.foreign_key :active_storage_blobs, column: :blob_id, type: :uuid
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,23 +10,23 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_09_01_112748) do
+ActiveRecord::Schema.define(version: 2021_09_16_154020) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
 
-  create_table "active_storage_attachments", force: :cascade do |t|
+  create_table "active_storage_attachments", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
-    t.bigint "record_id", null: false
-    t.bigint "blob_id", null: false
+    t.uuid "record_id", null: false
+    t.uuid "blob_id", null: false
     t.datetime "created_at", null: false
     t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
     t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
   end
 
-  create_table "active_storage_blobs", force: :cascade do |t|
+  create_table "active_storage_blobs", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "key", null: false
     t.string "filename", null: false
     t.string "content_type"
@@ -38,8 +38,8 @@ ActiveRecord::Schema.define(version: 2021_09_01_112748) do
     t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
   end
 
-  create_table "active_storage_variant_records", force: :cascade do |t|
-    t.bigint "blob_id", null: false
+  create_table "active_storage_variant_records", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "blob_id", null: false
     t.string "variation_digest", null: false
     t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
   end

--- a/spec/factories/submission_factory.rb
+++ b/spec/factories/submission_factory.rb
@@ -16,4 +16,18 @@ FactoryBot.define do
   trait :in_progress do
     status { :in_progress }
   end
+
+  trait :completed do
+    status { :completed }
+  end
+
+  trait :with_attachment do
+    after :create do |submission|
+      submission.result.attach(io: File.open('spec/fixtures/test_result.json'),
+                               filename: "#{submission.id}.json",
+                               content_type: 'application/json',
+                               key: "submission/result/#{submission.id}")
+      submission.reload
+    end
+  end
 end

--- a/spec/fixtures/test_result.json
+++ b/spec/fixtures/test_result.json
@@ -1,0 +1,1 @@
+{ "data": "test_data" }

--- a/spec/requests/api/v1/submission_swagger_spec.rb
+++ b/spec/requests/api/v1/submission_swagger_spec.rb
@@ -1,0 +1,51 @@
+require 'rails_helper'
+require 'swagger_helper'
+
+RSpec.describe 'GET submission', type: :request, swagger_doc: 'v1/swagger.yaml' do
+  include AuthorisedRequestHelper
+
+  let(:token) { application.access_tokens.create! }
+  let(:Authorization) { "Bearer #{token.token}" }
+  let(:application) { dk_application }
+  let(:id) { submission.id }
+
+  path '/api/v1/submission/{id}' do
+    get 'Retrieves a submission' do
+      tags 'submission'
+      produces 'application/json'
+      consumes 'application/json'
+      security [{ oAuth: [] }]
+      parameter name: :id, in: :path, type: :string
+
+      response 200, 'completed submission found' do
+        let!(:submission) { create :submission, :completed, :with_attachment }
+        let(:expected_response) { { data: 'test_data' } }
+        run_test! do |response|
+          expect(response.media_type).to eq('application/json')
+          expect(JSON.parse(response.body).symbolize_keys).to eq(expected_response)
+        end
+      end
+
+      response 202, 'incomplete submission found' do
+        let!(:submission) { create :submission, :in_progress }
+        run_test!
+      end
+
+      response 500, 'submission has been completed but no result object is present' do
+        let!(:submission) { create :submission, :completed }
+        run_test!
+      end
+
+      response 404, 'submission not found' do
+        let(:id) { '1234' }
+        run_test!
+      end
+
+      response 401, 'Error: Unauthorized' do
+        let(:id) { '1234' }
+        let(:Authorization) { nil }
+        run_test!
+      end
+    end
+  end
+end

--- a/swagger/v1/swagger.yaml
+++ b/swagger/v1/swagger.yaml
@@ -10,8 +10,8 @@ paths:
       summary: Retrieves the status of a submission
       tags:
       - submission-status
-      secuirty:
-        - oAuth: []
+      security:
+      - oAuth: []
       parameters:
       - name: id
         in: path
@@ -24,7 +24,31 @@ paths:
         '404':
           description: submission not found
         '401':
-          description: 'Error: Unauthorised'
+          description: 'Error: Unauthorized'
+  "/api/v1/submission/{id}":
+    get:
+      summary: Retrieves a submission
+      tags:
+      - submission
+      security:
+      - oAuth: []
+      parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          description: completed submission found
+        '202':
+          description: incomplete submission found
+        '500':
+          description: submission has been completed but no result object is present
+        '404':
+          description: submission not found
+        '401':
+          description: 'Error: Unauthorized'
   "/api/v1/use_case/submit":
     parameters:
     - name: filter[use_case]


### PR DESCRIPTION
1. Drops and recreates the three ActiveStorage tables so that they use `UUID`s instead of `bigint`s for id fields. This is necessary because errors are frequently occurring when retrieving ActiveStorage attachments.  See:

https://stackoverflow.com/questions/51531441/rails-5-2-activestorage-with-uuids-on-postgresql
https://edgeguides.rubyonrails.org/active_storage_overview.html#setup

🚨 This is destructive - all submission data in local, UAT and staging databases will be lost. I think this is acceptable as we're not live yet, but I can find a non-destructive approach if people prefer it 🚨 


2.  Adds a new route and controller to return the contents of a `submission`'s `result` object. Documents the new endpoint with swagger.

* Returns `HTTP200` + the JSON contents of the result if the `submission` has completed and the `result` object exists.

* Returns `HTTP500` if the `submission` has completed but no `result` object exists.

* Returns `HTTP202` if the `submission` has not yet completed. (Would it also be worth including the submission status and/or a link to the `submission-status` endpoint in the response, so that the client has more information to go on?)

* Returns  `HTTP404` if the `submission` does not exist.

This change doesn't implement any authentication for the endpoint; that will need to be done in a subsequent ticket when [AP-2460](https://dsdmoj.atlassian.net/browse/AP-2460) is done.
