### PR TITLE
Tech-debt: Update sidekiq deploys

### DIFF
--- a/deploy/helm/templates/deployment_sidekiq.yaml
+++ b/deploy/helm/templates/deployment_sidekiq.yaml
@@ -23,7 +23,7 @@ spec:
         - name: sidekiq-submissions
           image: '{{ .Values.image.repository }}:{{ .Values.image.tag }}'
           imagePullPolicy: IfNotPresent
-          command: ['bundle', 'exec', 'sidekiq', '-q submissions', '-c 1']
+          command: ['bundle', 'exec', 'sidekiq', '-q', 'submissions', '-c', '1']
           resources:
             limits:
               cpu: 500m
@@ -48,7 +48,7 @@ spec:
         - name: sidekiq-default
           image: '{{ .Values.image.repository }}:{{ .Values.image.tag }}'
           imagePullPolicy: IfNotPresent
-          command: ['bundle', 'exec', 'sidekiq', '-q default']
+          command: ['bundle', 'exec', 'sidekiq', '-q', 'default']
 {{ include "app.envs" . | nindent 10 }}
           resources:
             limits:


### PR DESCRIPTION
Update the sidekiq deployment invocation

The original way was causing spurious spaces to be added to the queuenames,
e.g. `:queues=>[" submissions"]` instead of `:queues=>["submissions"]`
This meant that jobs were not being started