### PR TITLE
Tech-debt: Rubocop tidy

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -5,7 +5,3 @@
 # one by one as the offenses are removed from the code base.
 # Note that changes in the inspected code, or installation of new
 # versions of RuboCop, may require this file to be generated again.
-
-Metrics/ClassLength:
-  Exclude:
-    - app/services/apply_get_test.rb


### PR DESCRIPTION
This was set to ignore because I knew it would get split/refactored,
it's not currently an issue so this means we will alert if future
changes make it break rules again