### PR TITLE
Fix: Update final state setting

### DIFF
--- a/app/workers/submission_process_worker.rb
+++ b/app/workers/submission_process_worker.rb
@@ -15,6 +15,6 @@ class SubmissionProcessWorker
     end
 
     SubmissionService.call(submission)
-    submission.update!(status: 'processed')
+    submission.update!(status: 'completed')
   end
 end

--- a/spec/workers/submission_process_worker_spec.rb
+++ b/spec/workers/submission_process_worker_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe SubmissionProcessWorker do
 
     it 'updates the submission status' do
       subject
-      expect(submission.status).to eq('processed')
+      expect(submission.status).to eq('completed')
     end
 
     context 'when the retry is exceeding the max retries' do


### PR DESCRIPTION
## What

There was a disconnect between the successful completion of
the job and the value checked when displaying the outcome

SubmissionProcessWork set state to `processed`, SubmissionController checked for submission.status to equal `completed`

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
- You should have run `NOCOVERAGE=true rake rswag` to ensure the swagger docs are up-to-date
