### PR TITLE
Fix: Add processing status to submission

### DIFF
--- a/app/workers/submission_process_worker.rb
+++ b/app/workers/submission_process_worker.rb
@@ -7,6 +7,7 @@ class SubmissionProcessWorker
 
   def perform(submission_id)
     submission = Submission.find(submission_id)
+    submission.update!(status: 'processing')
 
     if @retry_count.to_i >= MAX_RETRIES
       submission.update!(status: 'failed')


### PR DESCRIPTION
## What

While running a test I couldn't work out why the status endpoint stayed on `created` until it was suddenly `completed`

This allows users to see that the process has started when querying the status endpoint

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
- You should have run `NOCOVERAGE=true rake rswag` to ensure the swagger docs are up-to-date
