### PR TITLE
Align submission statuses in code and tests

### DIFF
--- a/spec/factories/submission_factory.rb
+++ b/spec/factories/submission_factory.rb
@@ -13,12 +13,16 @@ FactoryBot.define do
     end_date { start_date + 3.months }
   end
 
-  trait :in_progress do
-    status { :in_progress }
+  trait :processing do
+    status { :processing }
   end
 
   trait :completed do
     status { :completed }
+  end
+
+  trait :failed do
+    status { :failed }
   end
 
   trait :with_attachment do

--- a/spec/requests/api/v1/submissions_swagger_spec.rb
+++ b/spec/requests/api/v1/submissions_swagger_spec.rb
@@ -98,7 +98,7 @@ RSpec.describe 'GET submission', type: :request, swagger_doc: 'v1/swagger.yaml' 
 
   context 'status' do
     let(:application) { dk_application }
-    let!(:submission) { create :submission, :in_progress }
+    let!(:submission) { create :submission, :processing }
     let(:id) { submission.id }
 
     path '/api/v1/submission/status/{id}' do
@@ -113,7 +113,7 @@ RSpec.describe 'GET submission', type: :request, swagger_doc: 'v1/swagger.yaml' 
           let(:expected_response) do
             {
               submission: id,
-              status: 'in_progress',
+              status: 'processing',
               _links: [
                 href: "http://www.example.com/api/v1/submission/status/#{id}"
               ]
@@ -161,11 +161,11 @@ RSpec.describe 'GET submission', type: :request, swagger_doc: 'v1/swagger.yaml' 
         end
 
         response 202, 'incomplete submission found' do
-          let!(:submission) { create :submission, :in_progress }
+          let!(:submission) { create :submission, :processing }
           let(:expected_response) do
             {
               submission: id,
-              status: 'in_progress',
+              status: 'processing',
               _links: [
                 href: "http://www.example.com/api/v1/submission/status/#{id}"
               ]


### PR DESCRIPTION
## What

The names of submission statuses in tests have got slightly out of sync with those used in code. 

This PR renames the `in_progess` status to `processing` in the `Submission` factory and updates tests appropriately.

It also adds the `failed` status so that the factory fully reflects the four possible statuses of a submission: `created`, `processing`, `completed`, and `failed`.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
- You should have run `NOCOVERAGE=true rake rswag` to ensure the swagger docs are up-to-date
