### PR TITLE
AP-2522 update submission/status endpoint

### DIFF
--- a/app/controllers/api/V1/submissions_controller.rb
+++ b/app/controllers/api/V1/submissions_controller.rb
@@ -12,7 +12,7 @@ module Api
 
         SubmissionProcessWorker.perform_async(submission.id)
         render json: { id: submission.id,
-                       _links: [href: "#{request.base_url}/api/v1/submission-status/#{submission.id}"] },
+                       _links: [href: "#{request.base_url}/api/v1/submission/status/#{submission.id}"] },
                status: :accepted
         #  TO DO show errors when the request does not include all required data
         # else

--- a/app/controllers/api/V1/submissions_controller.rb
+++ b/app/controllers/api/V1/submissions_controller.rb
@@ -22,7 +22,8 @@ module Api
       def status
         render json: { submission: submission.id,
                        status: submission.status,
-                       _links: [href: "#{request.base_url}/api/v1/submission/status/#{submission.id}"] }
+                       _links: [href: "#{request.base_url}/api/v1/submission/#{result_or_status}/#{submission.id}"] },
+               status: return_status
       rescue ActiveRecord::RecordNotFound
         render status: :not_found
       end
@@ -90,6 +91,10 @@ module Api
 
       def completed_but_no_attachment?
         submission.status.eql?('completed') && attachment.nil?
+      end
+
+      def result_or_status
+        submission.status.eql?('completed') ? 'result' : 'status'
       end
     end
   end

--- a/spec/requests/api/v1/submissions_swagger_spec.rb
+++ b/spec/requests/api/v1/submissions_swagger_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe 'GET submission', type: :request, swagger_doc: 'v1/swagger.yaml' 
             expect(response.media_type).to eq('application/json')
             expect(response.body).to match(/id/)
             expect(response.body).to match(/_links/)
-            expect(JSON.parse(response.body)['_links'].first['href']).to match(%r{http://www.example.com/api/v1/submission-status/})
+            expect(JSON.parse(response.body)['_links'].first['href']).to match(%r{http://www.example.com/api/v1/submission/status/})
           end
         end
 

--- a/spec/requests/api/v1/submissions_swagger_spec.rb
+++ b/spec/requests/api/v1/submissions_swagger_spec.rb
@@ -110,7 +110,7 @@ RSpec.describe 'GET submission', type: :request, swagger_doc: 'v1/swagger.yaml' 
         parameter name: :id, in: :path, type: :string
 
         context 'when the submission has not completed' do
-          response '202', 'incomplete submission found' do
+          response 202, 'Submission still processing' do
             let(:expected_response) do
               {
                 submission: id,
@@ -129,7 +129,7 @@ RSpec.describe 'GET submission', type: :request, swagger_doc: 'v1/swagger.yaml' 
 
         context 'when the submission has completed' do
           let!(:submission) { create :submission, :completed, :with_attachment }
-          response '200', 'complete submission found' do
+          response 200, 'Submission complete' do
             let(:expected_response) do
               {
                 submission: id,
@@ -146,7 +146,7 @@ RSpec.describe 'GET submission', type: :request, swagger_doc: 'v1/swagger.yaml' 
           end
         end
 
-        response '404', 'submission not found' do
+        response 404, 'Submission not found' do
           let(:id) { '1234' }
           run_test!
         end
@@ -172,7 +172,7 @@ RSpec.describe 'GET submission', type: :request, swagger_doc: 'v1/swagger.yaml' 
         security [{ oAuth: [] }]
         parameter name: :id, in: :path, type: :string
 
-        response 200, 'completed submission found' do
+        response 200, 'Submission complete' do
           let!(:submission) { create :submission, :completed, :with_attachment }
           let(:expected_response) { { data: 'test_data' } }
           run_test! do |response|
@@ -181,7 +181,7 @@ RSpec.describe 'GET submission', type: :request, swagger_doc: 'v1/swagger.yaml' 
           end
         end
 
-        response 202, 'incomplete submission found' do
+        response 202, 'Submission still processing' do
           let!(:submission) { create :submission, :processing }
           let(:expected_response) do
             {
@@ -198,7 +198,7 @@ RSpec.describe 'GET submission', type: :request, swagger_doc: 'v1/swagger.yaml' 
           end
         end
 
-        response 500, 'submission has been completed but no result object is present' do
+        response 500, 'Submission complete but no result object is present' do
           let!(:submission) { create :submission, :completed }
           let(:expected_response) do
             {
@@ -212,7 +212,7 @@ RSpec.describe 'GET submission', type: :request, swagger_doc: 'v1/swagger.yaml' 
           end
         end
 
-        response 404, 'submission not found' do
+        response 404, 'Submission not found' do
           let(:id) { '1234' }
           run_test!
         end

--- a/spec/requests/api/v1/submissions_swagger_spec.rb
+++ b/spec/requests/api/v1/submissions_swagger_spec.rb
@@ -109,19 +109,40 @@ RSpec.describe 'GET submission', type: :request, swagger_doc: 'v1/swagger.yaml' 
         security [{ oAuth: [] }]
         parameter name: :id, in: :path, type: :string
 
-        response '200', 'submission found' do
-          let(:expected_response) do
-            {
-              submission: id,
-              status: 'processing',
-              _links: [
-                href: "http://www.example.com/api/v1/submission/status/#{id}"
-              ]
-            }
+        context 'when the submission has not completed' do
+          response '202', 'incomplete submission found' do
+            let(:expected_response) do
+              {
+                submission: id,
+                status: 'processing',
+                _links: [
+                  href: "http://www.example.com/api/v1/submission/status/#{id}"
+                ]
+              }
+            end
+            run_test! do |response|
+              expect(response.media_type).to eq('application/json')
+              expect(JSON.parse(response.body, symbolize_names: true)).to eq(expected_response)
+            end
           end
-          run_test! do |response|
-            expect(response.media_type).to eq('application/json')
-            expect(JSON.parse(response.body, symbolize_names: true)).to eq(expected_response)
+        end
+
+        context 'when the submission has completed' do
+          let!(:submission) { create :submission, :completed, :with_attachment }
+          response '200', 'complete submission found' do
+            let(:expected_response) do
+              {
+                submission: id,
+                status: 'completed',
+                _links: [
+                  href: "http://www.example.com/api/v1/submission/result/#{id}"
+                ]
+              }
+            end
+            run_test! do |response|
+              expect(response.media_type).to eq('application/json')
+              expect(JSON.parse(response.body, symbolize_names: true)).to eq(expected_response)
+            end
           end
         end
 

--- a/swagger/v1/swagger.yaml
+++ b/swagger/v1/swagger.yaml
@@ -77,8 +77,10 @@ paths:
         schema:
           type: string
       responses:
+        '202':
+          description: incomplete submission found
         '200':
-          description: submission found
+          description: complete submission found
         '404':
           description: submission not found
         '401':

--- a/swagger/v1/swagger.yaml
+++ b/swagger/v1/swagger.yaml
@@ -78,11 +78,11 @@ paths:
           type: string
       responses:
         '202':
-          description: incomplete submission found
+          description: Submission still processing
         '200':
-          description: complete submission found
+          description: Submission complete
         '404':
-          description: submission not found
+          description: Submission not found
         '401':
           description: 'Error: Unauthorized'
   "/api/v1/submission/result/{id}":
@@ -100,13 +100,13 @@ paths:
           type: string
       responses:
         '200':
-          description: completed submission found
+          description: Submission complete
         '202':
-          description: incomplete submission found
+          description: Submission still processing
         '500':
-          description: submission has been completed but no result object is present
+          description: Submission complete but no result object is present
         '404':
-          description: submission not found
+          description: Submission not found
         '401':
           description: 'Error: Unauthorized'
   "/api/v1/use_case/one":


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-2522)

Updates the `submission/status` endpoint so that it returns a link to itself with an `HTTP 202 Accepted` status when a submission has not completed, and a link to `submission/result `with an `HTTP 200 OK` status when a submission has completed.

Also fixes an incorrect call to the now-deprecated `submission-status` endpoint. 

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
- You should have run `NOCOVERAGE=true rake rswag` to ensure the swagger docs are up-to-date
