### PR TITLE
AP-2516 improve error handling

### DIFF
--- a/app/models/errors.rb
+++ b/app/models/errors.rb
@@ -1,3 +1,5 @@
 module Errors
   class ContractError < StandardError; end
+
+  class ClientDetailsMismatchError < StandardError; end
 end

--- a/app/models/errors.rb
+++ b/app/models/errors.rb
@@ -2,4 +2,6 @@ module Errors
   class ContractError < StandardError; end
 
   class ClientDetailsMismatchError < StandardError; end
+
+  class SentryIgnoresThisSidekiqFailError < StandardError; end
 end

--- a/app/models/errors.rb
+++ b/app/models/errors.rb
@@ -1,7 +1,7 @@
 module Errors
   class ContractError < StandardError; end
 
-  class ClientDetailsMismatchError < StandardError; end
+  class CitizenDetailsMismatchError < StandardError; end
 
   class SentryIgnoresThisSidekiqFailError < StandardError; end
 end

--- a/app/services/concerns/submission_processable.rb
+++ b/app/services/concerns/submission_processable.rb
@@ -79,6 +79,8 @@ module SubmissionProcessable
     uri = '/individuals/matching'
     response = RestClient.post("#{host}#{uri}", request_payload, build_headers(uri))
     JSON.parse(response, object_class: OpenStruct)._links.individual.href
+  rescue RestClient::ExceptionWithResponse => e
+    raise Errors::ClientDetailsMismatchError, 'User details not matched' if response_code(e, 'MATCHING_FAILED')
   end
 
   def request_payload
@@ -99,5 +101,9 @@ module SubmissionProcessable
 
   def host
     @host ||= @use_case.host
+  end
+
+  def response_code(error, text)
+    JSON.parse(error.response.body)['code'].match /#{text}/
   end
 end

--- a/app/services/concerns/submission_processable.rb
+++ b/app/services/concerns/submission_processable.rb
@@ -80,7 +80,7 @@ module SubmissionProcessable
     response = RestClient.post("#{host}#{uri}", request_payload, build_headers(uri))
     JSON.parse(response, object_class: OpenStruct)._links.individual.href
   rescue RestClient::ExceptionWithResponse => e
-    raise Errors::ClientDetailsMismatchError, 'User details not matched' if response_code(e, 'MATCHING_FAILED')
+    raise Errors::CitizenDetailsMismatchError, 'User details not matched' if response_code(e, 'MATCHING_FAILED')
   end
 
   def request_payload

--- a/app/services/submission_service.rb
+++ b/app/services/submission_service.rb
@@ -19,9 +19,11 @@ class SubmissionService
     @result = { data: [{ correlation_id: @correlation_id }] }
     data = request_and_extract_data(request_match_id)
     process_next_steps(data)
-    @submission.result.attach(io: StringIO.new(@result.to_json),
-                              filename: "#{@submission.id}.json",
-                              content_type: 'application/json',
-                              key: "submission/result/#{@submission.id}")
+  rescue Errors::ClientDetailsMismatchError
+    @result[:data] << { error: 'submitted client details could not be found in HMRC service' }
+    raise
+  ensure
+    @submission.result.attach(io: StringIO.new(@result.to_json), filename: "#{@submission.id}.json",
+                              content_type: 'application/json', key: "submission/result/#{@submission.id}")
   end
 end

--- a/app/services/submission_service.rb
+++ b/app/services/submission_service.rb
@@ -19,7 +19,7 @@ class SubmissionService
     @result = { data: [{ correlation_id: @correlation_id }] }
     data = request_and_extract_data(request_match_id)
     process_next_steps(data)
-  rescue Errors::ClientDetailsMismatchError
+  rescue Errors::CitizenDetailsMismatchError
     @result[:data] << { error: 'submitted client details could not be found in HMRC service' }
     raise
   ensure

--- a/app/workers/submission_process_worker.rb
+++ b/app/workers/submission_process_worker.rb
@@ -16,11 +16,10 @@ class SubmissionProcessWorker
 
     SubmissionService.call(submission)
     submission.update!(status: 'completed')
-  rescue Errors::ClientDetailsMismatchError, StandardError
-    if @retry_count >= MAX_RETRIES
-      submission.update!(status: 'failed')
-      raise
-    end
+  rescue Errors::ClientDetailsMismatchError
+    submission.update!(status: 'failed')
+  rescue StandardError
+    submission.update!(status: 'failed') && raise if @retry_count >= MAX_RETRIES
 
     raise Errors::SentryIgnoresThisSidekiqFailError, retry_error_message(submission_id)
   end

--- a/app/workers/submission_process_worker.rb
+++ b/app/workers/submission_process_worker.rb
@@ -16,7 +16,7 @@ class SubmissionProcessWorker
 
     SubmissionService.call(submission)
     submission.update!(status: 'completed')
-  rescue Errors::ClientDetailsMismatchError
+  rescue Errors::CitizenDetailsMismatchError
     submission.update!(status: 'failed')
   rescue StandardError
     submission.update!(status: 'failed') && raise if @retry_count >= MAX_RETRIES

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -3,7 +3,7 @@ Sentry.init do |config|
   config.breadcrumbs_logger = %i[active_support_logger http_logger]
   config.environment = Settings.sentry.environment
   config.excluded_exceptions += %w[
-    TestWorker::SentryIgnoresThisSidekiqFailError
+    Errors::SentryIgnoresThisSidekiqFailError
   ]
   # Send 5% of non-ping transactions for performance monitoring
   # :nocov:

--- a/spec/cassettes/use_case_one_fail.yml
+++ b/spec/cassettes/use_case_one_fail.yml
@@ -1,0 +1,52 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: "<SETTINGS__CREDENTIALS__HOST>/individuals/matching"
+    body:
+      encoding: UTF-8
+      string: '{"firstName":"this user","lastName":"does-not-exist","nino":"MN212451D","dateOfBirth":"1992-07-22"}'
+    headers:
+      Accept:
+      - application/vnd.hmrc.2.0+json
+      User-Agent:
+      - rest-client/2.1.0 (darwin19 x86_64) ruby/3.0.2p107
+      Correlationid:
+      - bd612fe9-4560-432b-be34-c04a89c1d585
+      Authorization:
+      - Bearer dummy_bearer_token
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '99'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Host:
+      - test-api.service.hmrc.gov.uk
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Content-Type:
+      - application/json
+      Cache-Control:
+      - no-cache
+      X-Envoy-Upstream-Service-Time:
+      - '84'
+      Strict-Transport-Security:
+      - max-age=31536000;
+      Content-Security-Policy:
+      - default-src 'self'
+      Content-Length:
+      - '85'
+      Date:
+      - Fri, 24 Sep 2021 09:20:18 GMT
+      Connection:
+      - close
+    body:
+      encoding: UTF-8
+      string: '{"code":"MATCHING_FAILED","message":"There is no match for the information
+        provided"}'
+  recorded_at: Fri, 24 Sep 2021 09:20:18 GMT
+recorded_with: VCR 6.0.0

--- a/spec/services/submission_service_spec.rb
+++ b/spec/services/submission_service_spec.rb
@@ -61,8 +61,9 @@ RSpec.describe SubmissionService, vcr: { cassette_name: 'use_case_one_success' }
         }
       end
 
-      it 'raises a ClientDetailsMismatch error' do
+      it 'raises an error and records the error in the result' do
         expect { subject }.to raise_error Errors::ClientDetailsMismatchError, 'User details not matched'
+        expect(submission.result.blob.download).to match(/submitted client details could not be found in HMRC service/)
       end
     end
 

--- a/spec/services/submission_service_spec.rb
+++ b/spec/services/submission_service_spec.rb
@@ -46,6 +46,26 @@ RSpec.describe SubmissionService, vcr: { cassette_name: 'use_case_one_success' }
       expect(submission.result.content_type).to eq 'application/json'
     end
 
+    context 'when the details are complete but not found on the calling service',
+            vcr: { cassette_name: 'use_case_one_fail' } do
+      let(:data) do
+        {
+          use_case: 'one',
+          first_name: 'this user',
+          last_name: 'does-not-exist',
+          nino: 'MN212451D',
+          dob: '1992-07-22',
+          start_date: '2020-08-01',
+          end_date: '2020-10-01',
+          oauth_application: application
+        }
+      end
+
+      it 'raises a ClientDetailsMismatch error' do
+        expect { subject }.to raise_error Errors::ClientDetailsMismatchError, 'User details not matched'
+      end
+    end
+
     context 'RestClient::InternalServerError' do
       before do
         allow(RestClient).to receive(:get).with(any_args).and_raise(RestClient::InternalServerError)

--- a/spec/services/submission_service_spec.rb
+++ b/spec/services/submission_service_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe SubmissionService, vcr: { cassette_name: 'use_case_one_success' }
       end
 
       it 'raises an error and records the error in the result' do
-        expect { subject }.to raise_error Errors::ClientDetailsMismatchError, 'User details not matched'
+        expect { subject }.to raise_error Errors::CitizenDetailsMismatchError, 'User details not matched'
         expect(submission.result.blob.download).to match(/submitted client details could not be found in HMRC service/)
       end
     end

--- a/spec/workers/submission_process_worker_spec.rb
+++ b/spec/workers/submission_process_worker_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe SubmissionProcessWorker do
     context 'when submission errors' do
       context 'with a client details mismatch error' do
         before do
-          allow(SubmissionService).to receive(:call).and_raise(Errors::ClientDetailsMismatchError)
+          allow(SubmissionService).to receive(:call).and_raise(Errors::CitizenDetailsMismatchError)
           worker.retry_count = 0
         end
 

--- a/spec/workers/submission_process_worker_spec.rb
+++ b/spec/workers/submission_process_worker_spec.rb
@@ -26,32 +26,46 @@ RSpec.describe SubmissionProcessWorker do
     end
 
     context 'when submission errors' do
-      before do
-        allow(SubmissionService).to receive(:call).and_raise(StandardError, 'A problem occurred')
-      end
-
-      context 'before the final retry' do
-        before { worker.retry_count = 2 }
-
-        it 'raises a not tracked error and leaves the status' do
-          expect { subject }.to raise_error Errors::SentryIgnoresThisSidekiqFailError
-          expect(submission.status).to eq 'processing'
+      context 'with a client details mismatch error' do
+        before do
+          allow(SubmissionService).to receive(:call).and_raise(Errors::ClientDetailsMismatchError)
+          worker.retry_count = 0
         end
-      end
 
-      context 'when the retry is at the max retries' do
-        let(:expected_message) { "Moving SubmissionProcessWorker# to dead set, it failed with: /An error occured\n" }
-
-        before { worker.retry_count = 3 }
-
-        it 'updates the submission status' do
-          expect { subject }.to raise_error StandardError, 'A problem occurred'
+        it 'updates the submission status amd records the error ' do
+          subject
           expect(submission.status).to eq('failed')
         end
+      end
 
-        it 'notifies sentry of the deadset addition' do
-          SubmissionProcessWorker.within_sidekiq_retries_exhausted_block do
-            expect(Sentry).to receive(:capture_message).with(expected_message)
+      context 'with a generic error' do
+        before do
+          allow(SubmissionService).to receive(:call).and_raise(StandardError, 'A problem occurred')
+        end
+
+        context 'before the final retry' do
+          before { worker.retry_count = 2 }
+
+          it 'raises a not tracked error and leaves the status' do
+            expect { subject }.to raise_error Errors::SentryIgnoresThisSidekiqFailError
+            expect(submission.status).to eq 'processing'
+          end
+        end
+
+        context 'when the retry is at the max retries' do
+          let(:expected_message) { "Moving SubmissionProcessWorker# to dead set, it failed with: /An error occured\n" }
+
+          before { worker.retry_count = 3 }
+
+          it 'updates the submission status' do
+            expect { subject }.to raise_error StandardError, 'A problem occurred'
+            expect(submission.status).to eq('failed')
+          end
+
+          it 'notifies sentry of the deadset addition' do
+            SubmissionProcessWorker.within_sidekiq_retries_exhausted_block do
+              expect(Sentry).to receive(:capture_message).with(expected_message)
+            end
           end
         end
       end


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-2516)

When we send a full set of values to the API but it cannot find a matching individual it returns a 404 with 
```json
{
  "code" : "MATCHING_FAILED",
  "message" : "There is no match for the information provided" 
}
``` 
 
This error handles that at each level and will automatically 
* stop retrying the sidekiq job
* set the submission status to `failed` and;
* record a dataset so that calling services will see what the error was

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
- You should have run `NOCOVERAGE=true rake rswag` to ensure the swagger docs are up-to-date
