### PR TITLE
Add test coverage for RestClient::TooManyRequests

### DIFF
--- a/app/services/concerns/submission_processable.rb
+++ b/app/services/concerns/submission_processable.rb
@@ -66,11 +66,9 @@ module SubmissionProcessable
     response = RestClient.get("#{host}#{uri}", Endpoint::Headers.call(uri, @correlation_id, @use_case.bearer_token))
     JSON.parse(response)
   rescue RestClient::TooManyRequests
-    # :nocov:
     Rails.logger.info "Rate limited while calling #{uri}: waiting then trying again"
     sleep(0.33)
     request_endpoint(uri)
-    # :nocov:
   rescue RestClient::InternalServerError, RestClient::NotFound
     'INTERNAL_SERVER_ERROR' # TODO: improve this, hard to do currently as only the live service fails
   end


### PR DESCRIPTION
## What

[Link to story] N/A - increase test coverage

Describe what you did and why.

Added tests for HMRC raising TooManyRequests
Removed :nocov labels

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
- You should have run `NOCOVERAGE=true rake rswag` to ensure the swagger docs are up-to-date
