### PR TITLE
Update result blocks

### DIFF
--- a/app/controllers/api/V1/submissions_controller.rb
+++ b/app/controllers/api/V1/submissions_controller.rb
@@ -43,14 +43,14 @@ module Api
       end
 
       def return_body
-        if return_status.eql?(:ok)
-          attachment.blob.download
-        elsif completed_but_no_attachment?
-          { code: 'INCOMPLETE_SUBMISSION', message: 'Process complete but no result available' }
-        else
-          { submission: submission.id, status: submission.status,
-            _links: [href: "#{request.base_url}/api/v1/submission/status/#{submission.id}"] }
-        end
+        data_hash = if return_status.eql?(:ok)
+                      JSON.parse(attachment.blob.download, symbolize_names: true)
+                    elsif completed_but_no_attachment?
+                      { code: 'INCOMPLETE_SUBMISSION', message: 'Process complete but no result available' }
+                    else
+                      { _links: [href: "#{request.base_url}/api/v1/submission/status/#{submission.id}"] }
+                    end
+        { submission: submission.id, status: submission.status }.merge(data_hash)
       end
 
       def unauthorised_use_case

--- a/app/services/submission_service.rb
+++ b/app/services/submission_service.rb
@@ -16,7 +16,7 @@ class SubmissionService
 
   def call(correlation_id: SecureRandom.uuid)
     @correlation_id = correlation_id
-    @result = { data: [{ correlation_id: @correlation_id }] }
+    @result = { data: [{ correlation_id: @correlation_id, use_case: @use_case.use_case }] }
     data = request_and_extract_data(request_match_id)
     process_next_steps(data)
   rescue Errors::CitizenDetailsMismatchError

--- a/spec/requests/api/v1/submissions_swagger_spec.rb
+++ b/spec/requests/api/v1/submissions_swagger_spec.rb
@@ -199,6 +199,8 @@ RSpec.describe 'GET submission', type: :request, swagger_doc: 'v1/swagger.yaml' 
           let!(:submission) { create :submission, :completed, oauth_application: application }
           let(:expected_response) do
             {
+              submission: id,
+              status: 'completed',
               code: 'INCOMPLETE_SUBMISSION',
               message: 'Process complete but no result available'
             }


### PR DESCRIPTION
## What

Ensure the submission_id and status are always returned, then there
is _either_ a `_links` or `data` object relevant to the status.  This
should allow calling services to identify without having to parse
status code and JSON key presence to try and work out if it has
completed successfully or why it failed

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
- You should have run `NOCOVERAGE=true rake rswag` to ensure the swagger docs are up-to-date
