### PR TITLE
AP-2646: Update CircleCI Docker images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,20 +14,20 @@ executors:
           TZ: Europe/London
   linting-executor:
     docker:
-      - image: circleci/ruby:3.0.2-node-browsers
+      - image: cimg/ruby:3.0.2-node
         environment:
           - RAILS_ENV=test
           - TZ: "Europe/London"
   test-executor:
     docker:
-      - image: circleci/ruby:3.0.2-node-browsers
+      - image: cimg/ruby:3.0.2-node
         environment:
           - RAILS_ENV=test
           - PGHOST=localhost
           - PGUSER=user
           - TZ: "Europe/London"
-      - image: circleci/redis:5.0
-      - image: postgres:10.5
+      - image: cimg/redis:5.0
+      - image: cimg/postgres:10.18
         environment:
           - POSTGRES_USER=user
           - POSTGRES_DB=laa_hmrc_interface_service_api_test


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-2646)

Update references to outdated `circleci/` prefixed docker images

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
- You should have run `NOCOVERAGE=true rake rswag` to ensure the swagger docs are up-to-date
