### PR TITLE
Split submission queues

### DIFF
--- a/app/controllers/api/V1/submissions_controller.rb
+++ b/app/controllers/api/V1/submissions_controller.rb
@@ -90,7 +90,8 @@ module Api
       end
 
       def process_submission(id)
-        SubmissionProcessWorker.perform_async(id)
+        queue = "uc-#{Submission.find(id).use_case}-#{QueueNameService.call}"
+        SubmissionProcessWorker.set(queue: queue).perform_async(id)
         render json: { id: id,
                        _links: [href: "#{request.base_url}/api/v1/submission/result/#{id}"] },
                status: :accepted

--- a/app/services/concerns/submission_processable.rb
+++ b/app/services/concerns/submission_processable.rb
@@ -11,6 +11,7 @@ module SubmissionProcessable
   end
 
   def request_and_extract_data(uri)
+    sleep(Settings.delay) # Having a fraction of a second pause reduces the instances of rate limiting that occur
     parsed_uri = build_uri(uri)
     data = request_endpoint(parsed_uri.for_calling)
     extract_data_from(data, parsed_uri)

--- a/bin/uat_deploy
+++ b/bin/uat_deploy
@@ -23,7 +23,7 @@ deploy() {
                 --set ingress.hosts="{$RELEASE_HOST}" \
                 --set ingress.annotations."external-dns\.alpha\.kubernetes\.io/set-identifier"="$IDENTIFIER" \
                 --set branch.name="$BRANCH_NAME" \
-                --set sidekiq.queue_name="$BRANCH_NAME-submissions"
+                --set sidekiq.queue_name="$BRANCH_NAME-"
 }
 
 deploy

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,0 +1,1 @@
+Sidekiq.logger = Rails.logger

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -67,3 +67,5 @@ smoke_test:
     start_date: 'store actual value as SETTINGS__SMOKE_TEST__USE_CASE_FOUR__START_DATE'
     end_date: 'store actual value as SETTINGS__SMOKE_TEST__USE_CASE_FOUR__END_DATE'
     correlation_id: 'store actual value as SETTINGS__SMOKE_TEST__USE_CASE_FOUR__CORRELATION_ID'
+
+delay: 0.15

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -31,3 +31,5 @@ sidekiq:
 
 sentry:
   environment: 'test'
+
+delay: 0

--- a/deploy/helm/templates/deployment_sidekiq.yaml
+++ b/deploy/helm/templates/deployment_sidekiq.yaml
@@ -20,10 +20,85 @@ spec:
         release: {{ .Release.Name }}
     spec:
       containers:
-        - name: sidekiq-submissions
+        - name: sidekiq-uc1
           image: '{{ .Values.image.repository }}:{{ .Values.image.tag }}'
           imagePullPolicy: IfNotPresent
-          command: ['bundle', 'exec', 'sidekiq', '-q', '{{ .Values.sidekiq.queue_name | default "submissions" }}', '-c', '1']
+          command: ['bundle', 'exec', 'sidekiq', '-q', 'uc-one-{{ .Values.sidekiq.queue_name }}submissions', '-c', '1'] # queue_name is set in bin/uat_deploy
+          resources:
+            limits:
+              cpu: 500m
+              memory: 1Gi
+            requests:
+              cpu: 10m
+              memory: 512Mi
+          ports:
+            - containerPort: 7433
+          livenessProbe:
+            exec:
+              command: ['bin/sidekiq_health_check']
+            initialDelaySeconds: 35
+            timeoutSeconds: 5
+            periodSeconds: 120
+          readinessProbe:
+            exec:
+              command: ['bin/sidekiq_health_check']
+            initialDelaySeconds: 35
+            timeoutSeconds: 5
+{{ include "app.envs" . | nindent 10 }}
+        - name: sidekiq-uc2
+          image: '{{ .Values.image.repository }}:{{ .Values.image.tag }}'
+          imagePullPolicy: IfNotPresent
+          command: ['bundle', 'exec', 'sidekiq', '-q', 'uc-two-{{ .Values.sidekiq.queue_name }}submissions', '-c', '1'] # queue_name is set in bin/uat_deploy
+          resources:
+            limits:
+              cpu: 500m
+              memory: 1Gi
+            requests:
+              cpu: 10m
+              memory: 512Mi
+          ports:
+            - containerPort: 7433
+          livenessProbe:
+            exec:
+              command: ['bin/sidekiq_health_check']
+            initialDelaySeconds: 35
+            timeoutSeconds: 5
+            periodSeconds: 120
+          readinessProbe:
+            exec:
+              command: ['bin/sidekiq_health_check']
+            initialDelaySeconds: 35
+            timeoutSeconds: 5
+{{ include "app.envs" . | nindent 10 }}
+        - name: sidekiq-uc3
+          image: '{{ .Values.image.repository }}:{{ .Values.image.tag }}'
+          imagePullPolicy: IfNotPresent
+          command: ['bundle', 'exec', 'sidekiq', '-q', 'uc-three-{{ .Values.sidekiq.queue_name }}submissions', '-c', '1'] # queue_name is set in bin/uat_deploy
+          resources:
+            limits:
+              cpu: 500m
+              memory: 1Gi
+            requests:
+              cpu: 10m
+              memory: 512Mi
+          ports:
+            - containerPort: 7433
+          livenessProbe:
+            exec:
+              command: ['bin/sidekiq_health_check']
+            initialDelaySeconds: 35
+            timeoutSeconds: 5
+            periodSeconds: 120
+          readinessProbe:
+            exec:
+              command: ['bin/sidekiq_health_check']
+            initialDelaySeconds: 35
+            timeoutSeconds: 5
+{{ include "app.envs" . | nindent 10 }}
+        - name: sidekiq-uc4
+          image: '{{ .Values.image.repository }}:{{ .Values.image.tag }}'
+          imagePullPolicy: IfNotPresent
+          command: ['bundle', 'exec', 'sidekiq', '-q', 'uc-four-{{ .Values.sidekiq.queue_name }}submissions', '-c', '1'] # queue_name is set in bin/uat_deploy
           resources:
             limits:
               cpu: 500m


### PR DESCRIPTION
## What

As a test of rate-limiting, it was identified that the rate limits only apply to each use case - this PR splits the queues in sidekiq so that a bulk upload of - say - use case 3 will not block single requests of use case 1

While testing it was also identified that a, very, minor delay (0.15 seconds) actually speeds up the overall time as it reduces the rate-limiting that occurs, and that actually makes the total time slightly smaller.
The delay is implemented as a Setting so that it can be set as 0(zero) for tests and 0.15 everywhere else

There is a spreadsheet of tests if anyone is interested!

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
- You should have run `NOCOVERAGE=true rake rswag` to ensure the swagger docs are up-to-date
