### PR TITLE
AP-2685: remove ostruct uses

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -39,12 +39,3 @@ Naming/InclusiveLanguage:
     master:
       AllowedRegex:
         - !ruby/regexp "/master.key/i"
-
-# Style/OpenStructUse added Nov 16th 2021 - warnings around openstruct security mean we
-# should not add more OpenStructs but this is not a 5 minute fix and needs a ticket so
-# we ignore the three files until they can be removed but throw a warning if more are added
-Style/OpenStructUse:
-  Exclude:
-    - app/services/submission_service.rb
-    - app/services/concerns/submission_processable.rb
-    - app/services/apply_get_test.rb

--- a/app/services/apply_get_test.rb
+++ b/app/services/apply_get_test.rb
@@ -1,6 +1,6 @@
 # :nocov:
 class ApplyGetTest
-  attr_reader :data
+  attr_reader :submission
 
   include SubmissionProcessable
 
@@ -8,14 +8,14 @@ class ApplyGetTest
     return unless args.keys.difference(%i[first_name last_name nino dob start_date end_date]).empty?
 
     @use_case = UseCase.new(use_case)
-    @data = JSON.parse({
+    @submission = JSON.parse({
       first_name: args[:first_name],
       last_name: args[:last_name],
       nino: args[:nino],
       dob: args[:dob],
       start_date: args[:start_date],
       end_date: args[:end_date]
-    }.to_json, object_class: OpenStruct)
+    }.to_json, object_class: Submission)
   end
 
   def self.call(use_case, **args)

--- a/app/services/concerns/submission_processable.rb
+++ b/app/services/concerns/submission_processable.rb
@@ -83,7 +83,12 @@ module SubmissionProcessable
   end
 
   def request_payload
-    { firstName: data.first_name, lastName: data.last_name, nino: data.nino, dateOfBirth: data.dob }.to_json
+    {
+      firstName: submission.first_name,
+      lastName: submission.last_name,
+      nino: submission.nino,
+      dateOfBirth: submission.dob
+    }.to_json
   end
 
   def extract_next_links(data)
@@ -91,7 +96,7 @@ module SubmissionProcessable
   end
 
   def build_uri(uri)
-    Endpoint::Uri.new(uri, use_case: @use_case.use_case, from_date: data.start_date, to_date: data.end_date)
+    Endpoint::Uri.new(uri, use_case: @use_case.use_case, from_date: submission.start_date, to_date: submission.end_date)
   end
 
   def build_headers(uri)

--- a/app/services/concerns/submission_processable.rb
+++ b/app/services/concerns/submission_processable.rb
@@ -77,7 +77,7 @@ module SubmissionProcessable
   def request_match_id
     uri = '/individuals/matching'
     response = RestClient.post("#{host}#{uri}", request_payload, build_headers(uri))
-    JSON.parse(response, object_class: OpenStruct)._links.individual.href
+    JSON.parse(response).dig('_links', 'individual', 'href')
   rescue RestClient::ExceptionWithResponse => e
     raise Errors::CitizenDetailsMismatchError, 'User details not matched' if response_code(e, 'MATCHING_FAILED')
   end

--- a/app/services/submission_service.rb
+++ b/app/services/submission_service.rb
@@ -1,12 +1,11 @@
 class SubmissionService
-  attr_reader :data
+  attr_reader :submission
 
   include SubmissionProcessable
 
   def initialize(use_case, submission)
     @use_case = UseCase.new(use_case)
     @submission = submission
-    @data = OpenStruct.new(@submission.as_json.except('use_case'))
   end
 
   def self.call(submission)


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-2685)

Remove OpenStruct uses from the code and remove the rubocop exemptions

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
- You should have run `NOCOVERAGE=true rake rswag` to ensure the swagger docs are up-to-date
