### PR TITLE
Bump CircleCI Slack Orb to 4.5.2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  slack: circleci/slack@4.4.4
+  slack: circleci/slack@4.5.2
 executors:
   basic-executor:
     docker:
@@ -98,7 +98,7 @@ references:
       name: Install System packages needed for testing
       command: |
         sudo apt-get update
-        sudo apt-get install -y postgresql-client 
+        sudo apt-get install -y postgresql-client
         sudo apt-get install -y git-crypt
   setup_database: &setup_database
     run:


### PR DESCRIPTION
## What

Bump CircleCI Slack Orb to 4.5.2.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
- You should have run `NOCOVERAGE=true rake rswag` to ensure the swagger docs are up-to-date
