### PR TITLE
AP-2786: Rails 7 migration test

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ RUN set -ex
 RUN apk --no-cache add --virtual build-dependencies \
                     build-base \
                     postgresql-dev \
+                    git \
 && apk --no-cache add postgresql-client
 
 RUN mkdir /app


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-2786)

Update the Gemfile to use the latest Rails versions

Update required gem sources for Rails 7 compliant gems

25 February:
Validates timeliness still awaiting an official update - this PR still referes to a fork to test functionality, see [this PR](https://github.com/adzap/validates_timeliness/pull/213) for the new forked gem source

<details>
<summary>outdated reports</summary>

11 Feb 2022 -

* rswag has been resolved
* validates timeliness is still awaiting an official update/release


As of 20 Jan 2022 -
* rswag has the relevant code in master but is awaiting a new gem release - see the conversation [here](https://github.com/rswag/rswag/issues/468)
* validates_timeliness has a number of PR's awaiting approval.  I have, temporarily, linked to a fork of the original gem so that we can see in principal that the Rails 7 migration will be easy see [this PR](https://github.com/adzap/validates_timeliness/pull/213) for the new forked gem source
</details>

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
- You should have run `NOCOVERAGE=true rake rswag` to ensure the swagger docs are up-to-date
