### PR TITLE
Fix: Reduce rubocop todo

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -140,12 +140,6 @@ RSpec/InstanceVariable:
     - 'spec/services/hmrc/sandbox/create_test_data_spec.rb'
     - 'spec/services/submission_service_spec.rb'
 
-# Offense count: 1
-# Cop supports --auto-correct.
-RSpec/LeadingSubject:
-  Exclude:
-    - 'spec/workers/submission_process_worker_spec.rb'
-
 # Offense count: 62
 # Configuration parameters: IgnoreSharedExamples.
 RSpec/NamedSubject:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -30,16 +30,6 @@ RSpec/ContextWording:
   Exclude:
     - 'spec/workers/submission_process_worker_spec.rb'
 
-# Offense count: 16
-# Cop supports --auto-correct.
-# Configuration parameters: SkipBlocks, EnforcedStyle.
-# SupportedStyles: described_class, explicit
-RSpec/DescribedClass:
-  Exclude:
-    - 'spec/models/submission_spec.rb'
-    - 'spec/services/endpoint/uri_spec.rb'
-    - 'spec/workers/submission_process_worker_spec.rb'
-
 # Offense count: 6
 RSpec/EmptyExampleGroup:
   Exclude:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -207,18 +207,6 @@ Rails/SaveBang:
     - 'app/controllers/api/V1/use_case_controller.rb'
     - 'spec/models/submission_spec.rb'
 
-# Offense count: 3
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyle, ProceduralMethods, FunctionalMethods, IgnoredMethods, AllowBracesOnProceduralOneLiners, BracesRequiredMethods.
-# SupportedStyles: line_count_based, semantic, braces_for_chaining, always_braces
-# ProceduralMethods: benchmark, bm, bmbm, create, each_with_object, measure, new, realtime, tap, with_object
-# FunctionalMethods: let, let!, subject, watch
-# IgnoredMethods: lambda, proc, it
-Style/BlockDelimiters:
-  Exclude:
-    - 'app/controllers/api/V1/submissions_controller.rb'
-    - 'spec/services/submission_service_spec.rb'
-
 # Offense count: 855
 # Cop supports --auto-correct.
 # Configuration parameters: EnforcedStyle, ConsistentQuotesInMultiline.

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -186,12 +186,6 @@ RSpec/VariableName:
     - 'spec/requests/api/v1/use_case_swagger_spec.rb'
 
 # Offense count: 1
-# Configuration parameters: IgnoreNameless, IgnoreSymbolicNames.
-RSpec/VerifiedDoubles:
-  Exclude:
-    - 'spec/requests/status_controller_spec.rb'
-
-# Offense count: 1
 # Configuration parameters: Include.
 # Include: db/migrate/*.rb
 Rails/CreateTableWithTimestamps:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -23,11 +23,6 @@ Layout/SpaceInsidePercentLiteralDelimiters:
     - 'db/migrate/20210831075846_create_active_storage_tables.active_storage.rb'
     - 'db/migrate/20210916154020_change_active_storage_ids_to_uuid.rb'
 
-# Offense count: 1
-RSpec/AnyInstance:
-  Exclude:
-    - 'spec/requests/smoke_test_swagger_spec.rb'
-
 # Offense count: 11
 # Configuration parameters: Prefixes.
 # Prefixes: when, with, without

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -6,13 +6,6 @@
 # Note that changes in the inspected code, or installation of new
 # versions of RuboCop, may require this file to be generated again.
 
-# Offense count: 14
-# Cop supports --auto-correct.
-# Configuration parameters: IndentationWidth.
-# SupportedStyles: outdent, indent
-Layout/AccessModifierIndentation:
-  EnforcedStyle: indent
-
 # Offense count: 12
 # Cop supports --auto-correct.
 # Configuration parameters: EnforcedStyle, EnforcedStyleForEmptyBrackets.

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -23,15 +23,11 @@ Layout/SpaceInsidePercentLiteralDelimiters:
     - 'db/migrate/20210831075846_create_active_storage_tables.active_storage.rb'
     - 'db/migrate/20210916154020_change_active_storage_ids_to_uuid.rb'
 
-# Offense count: 11
+# Offense count: 1
 # Configuration parameters: Prefixes.
 # Prefixes: when, with, without
 RSpec/ContextWording:
   Exclude:
-    - 'spec/requests/api/v1/submissions_swagger_spec.rb'
-    - 'spec/requests/status_controller_spec.rb'
-    - 'spec/services/bearer_token_spec.rb'
-    - 'spec/services/submission_service_spec.rb'
     - 'spec/workers/submission_process_worker_spec.rb'
 
 # Offense count: 16

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -123,15 +123,6 @@ RSpec/HookArgument:
   Exclude:
     - 'spec/spec_helper.rb'
 
-# Offense count: 3
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyle.
-# SupportedStyles: single_line_only, single_statement_only, disallow
-RSpec/ImplicitSubject:
-  Exclude:
-    - 'spec/models/submission_spec.rb'
-    - 'spec/services/endpoint/tax_years_for_spec.rb'
-
 # Offense count: 6
 # Configuration parameters: AssignmentOnly.
 RSpec/InstanceVariable:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -157,14 +157,6 @@ RSpec/NamedSubject:
     - 'spec/services/use_case_spec.rb'
     - 'spec/workers/submission_process_worker_spec.rb'
 
-# Offense count: 1
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyle.
-# SupportedStyles: not_to, to_not
-RSpec/NotToNot:
-  Exclude:
-    - 'spec/models/submission_spec.rb'
-
 # Offense count: 14
 RSpec/ScatteredSetup:
   Exclude:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -107,14 +107,6 @@ RSpec/ExampleWording:
   Exclude:
     - 'spec/services/queue_name_service_spec.rb'
 
-# Offense count: 14
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyle.
-# SupportedStyles: method_call, block
-RSpec/ExpectChange:
-  Exclude:
-    - 'spec/models/submission_spec.rb'
-
 # Offense count: 1
 # Cop supports --auto-correct.
 # Configuration parameters: EnforcedStyle.

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -102,13 +102,6 @@ RSpec/EmptyLineAfterSubject:
 
 # Offense count: 1
 # Cop supports --auto-correct.
-# Configuration parameters: CustomTransform, IgnoredWords.
-RSpec/ExampleWording:
-  Exclude:
-    - 'spec/services/queue_name_service_spec.rb'
-
-# Offense count: 1
-# Cop supports --auto-correct.
 # Configuration parameters: EnforcedStyle.
 # SupportedStyles: implicit, each, example
 RSpec/HookArgument:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -157,11 +157,6 @@ RSpec/ScatteredSetup:
     - 'spec/requests/api/v1/use_case_swagger_spec.rb'
     - 'spec/requests/smoke_test_swagger_spec.rb'
 
-# Offense count: 1
-RSpec/StubbedMock:
-  Exclude:
-    - 'spec/services/use_case_spec.rb'
-
 # Offense count: 15
 # Configuration parameters: IgnoredPatterns.
 # SupportedStyles: snake_case, camelCase

--- a/app/controllers/api/V1/submissions_controller.rb
+++ b/app/controllers/api/V1/submissions_controller.rb
@@ -30,7 +30,7 @@ module Api
         render status: :not_found
       end
 
-      private
+    private
 
       def return_status
         @return_status ||= if completed_but_no_attachment?

--- a/app/controllers/api/V1/use_case_controller.rb
+++ b/app/controllers/api/V1/use_case_controller.rb
@@ -26,7 +26,7 @@ module Api
         render json: result
       end
 
-      private
+    private
 
       def filtered_params
         params.require(:filter).permit(:use_case,

--- a/app/controllers/smoke_test_controller.rb
+++ b/app/controllers/smoke_test_controller.rb
@@ -12,7 +12,7 @@ class SmokeTestController < ApplicationController
     render status: status, json: { smoke_test_result: results }
   end
 
-  private
+private
 
   def run_tests
     {

--- a/app/controllers/status_controller.rb
+++ b/app/controllers/status_controller.rb
@@ -21,7 +21,7 @@ class StatusController < ApplicationController
     }
   end
 
-  private
+private
 
   def database_alive?
     ActiveRecord::Base.connection.active?

--- a/app/services/bearer_token.rb
+++ b/app/services/bearer_token.rb
@@ -16,7 +16,7 @@ class BearerToken
     parsed_json['access_token']
   end
 
-  private
+private
 
   def payload
     {

--- a/app/services/concerns/submission_processable.rb
+++ b/app/services/concerns/submission_processable.rb
@@ -1,7 +1,7 @@
 module SubmissionProcessable
   extend ActiveSupport::Concern
 
-  private
+private
 
   def process_next_steps(data)
     return if data.to_s.eql?('INTERNAL_SERVER_ERROR')

--- a/app/services/endpoint/headers.rb
+++ b/app/services/endpoint/headers.rb
@@ -17,7 +17,7 @@ module Endpoint
       new(href, correlation_id, token).call
     end
 
-    private
+  private
 
     def base_headers
       {

--- a/app/services/endpoint/tax_years_for.rb
+++ b/app/services/endpoint/tax_years_for.rb
@@ -17,7 +17,7 @@ module Endpoint
       "#{financial_year_start.year}-#{(financial_year_start + 1.year).strftime('%y')}"
     end
 
-    private
+  private
 
     def date_is_pre_april_6th
       date.month < 4 || (date.month.eql?(4) && date.day < 6)

--- a/app/services/endpoint/uri.rb
+++ b/app/services/endpoint/uri.rb
@@ -21,7 +21,7 @@ module Endpoint
       Rack::Utils.parse_query(@href).keys[0].gsub(/\?.*/, '').split('/')[range].join('/')
     end
 
-    private
+  private
 
     def tax_years_from
       TaxYearsFor.call(Date.parse(@options[:from_date]))

--- a/app/services/hmrc/sandbox/create_test_data.rb
+++ b/app/services/hmrc/sandbox/create_test_data.rb
@@ -27,7 +27,7 @@ module HMRC
         response.code.eql?(201)
       end
 
-      private
+    private
 
       def build_dates
         if @dates == []

--- a/app/services/smoke_test.rb
+++ b/app/services/smoke_test.rb
@@ -16,7 +16,7 @@ class SmokeTest
     result
   end
 
-  private
+private
 
   def expected_response
     @expected_response ||= File.read("./spec/fixtures/smoke_tests/use_case_#{@use_case}.json")

--- a/app/services/use_case.rb
+++ b/app/services/use_case.rb
@@ -12,7 +12,7 @@ class UseCase
     @host ||= Settings.credentials.send(@use_case).host
   end
 
-  private
+private
 
   def check_bearer_token
     generate_new_token if current_token.nil?

--- a/app/workers/submission_process_worker.rb
+++ b/app/workers/submission_process_worker.rb
@@ -24,7 +24,7 @@ class SubmissionProcessWorker
     raise Errors::SentryIgnoresThisSidekiqFailError, retry_error_message(submission_id)
   end
 
-  private
+private
 
   def retry_error_message(submission_id)
     "Retry #{@retry_count.to_i} for SubmissionProcessWorker: #{submission_id}"

--- a/db/populators/oauth_account_populator.rb
+++ b/db/populators/oauth_account_populator.rb
@@ -9,7 +9,7 @@ class OauthAccountPopulator
     seed_data.each { |seed_row| populate(seed_row) }.freeze unless Settings.environment.eql?('live')
   end
 
-  private
+private
 
   def populate(seed_row)
     name, scopes, uid, secret = seed_row

--- a/spec/models/submission_spec.rb
+++ b/spec/models/submission_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe Submission, type: :model do
     context 'with first name missing' do
       before { params.delete(:first_name) }
       it 'does not persist model' do
-        expect { subject.save }.not_to(change { Submission.count })
+        expect { subject.save }.not_to(change(Submission, :count))
       end
 
       it 'raises an error' do
@@ -49,7 +49,7 @@ RSpec.describe Submission, type: :model do
     context 'with last name missing' do
       before { params.delete(:last_name) }
       it 'does not persist model' do
-        expect { subject.save }.not_to(change { Submission.count })
+        expect { subject.save }.not_to(change(Submission, :count))
       end
 
       it 'raises an error' do
@@ -62,7 +62,7 @@ RSpec.describe Submission, type: :model do
       context 'with nino missing' do
         before { params.delete(:nino) }
         it 'does not persist model' do
-          expect { subject.save }.not_to(change { Submission.count })
+          expect { subject.save }.not_to(change(Submission, :count))
         end
 
         it 'raises an error' do
@@ -74,7 +74,7 @@ RSpec.describe Submission, type: :model do
       context 'with an invalid nino' do
         before { params[:nino] = 'invalid_nino' }
         it 'does not persist model' do
-          expect { subject.save }.not_to(change { Submission.count })
+          expect { subject.save }.not_to(change(Submission, :count))
         end
 
         it 'raises an error' do
@@ -88,7 +88,7 @@ RSpec.describe Submission, type: :model do
       context 'with dob missing' do
         before { params.delete(:dob) }
         it 'does not persist model' do
-          expect { subject.save }.not_to(change { Submission.count })
+          expect { subject.save }.not_to(change(Submission, :count))
         end
 
         it 'raises an error' do
@@ -100,7 +100,7 @@ RSpec.describe Submission, type: :model do
       context 'with a badly formatted dob' do
         before { params[:dob] = 'date' }
         it 'does not persist model' do
-          expect { subject.save }.not_to(change { Submission.count })
+          expect { subject.save }.not_to(change(Submission, :count))
         end
 
         it 'raises an error' do
@@ -112,7 +112,7 @@ RSpec.describe Submission, type: :model do
       context 'with a dob in the future' do
         before { params[:dob] = Time.zone.today + 1 }
         it 'does not persist model' do
-          expect { subject.save }.not_to(change { Submission.count })
+          expect { subject.save }.not_to(change(Submission, :count))
         end
 
         it 'raises an error' do
@@ -126,7 +126,7 @@ RSpec.describe Submission, type: :model do
       context 'with start_date missing' do
         before { params.delete(:start_date) }
         it 'does not persist model' do
-          expect { subject.save }.not_to(change { Submission.count })
+          expect { subject.save }.not_to(change(Submission, :count))
         end
 
         it 'raises an error' do
@@ -138,7 +138,7 @@ RSpec.describe Submission, type: :model do
       context 'with a badly formatted start_date' do
         before { params[:start_date] = 'date' }
         it 'does not persist model' do
-          expect { subject.save }.not_to(change { Submission.count })
+          expect { subject.save }.not_to(change(Submission, :count))
         end
 
         it 'raises an error' do
@@ -150,7 +150,7 @@ RSpec.describe Submission, type: :model do
       context 'with a start_date in the future' do
         before { params[:start_date] = Time.zone.today + 1 }
         it 'does not persist model' do
-          expect { subject.save }.not_to(change { Submission.count })
+          expect { subject.save }.not_to(change(Submission, :count))
         end
 
         it 'raises an error' do
@@ -164,7 +164,7 @@ RSpec.describe Submission, type: :model do
       context 'with end_date missing' do
         before { params.delete(:end_date) }
         it 'does not persist model' do
-          expect { subject.save }.not_to(change { Submission.count })
+          expect { subject.save }.not_to(change(Submission, :count))
         end
 
         it 'raises an error' do
@@ -176,7 +176,7 @@ RSpec.describe Submission, type: :model do
       context 'with a badly formatted end_date' do
         before { params[:end_date] = 'date' }
         it 'does not persist model' do
-          expect { subject.save }.not_to(change { Submission.count })
+          expect { subject.save }.not_to(change(Submission, :count))
         end
 
         it 'raises an error' do
@@ -188,7 +188,7 @@ RSpec.describe Submission, type: :model do
       context 'with an end_date in the future' do
         before { params[:end_date] = Time.zone.today + 1 }
         it 'does not persist model' do
-          expect { subject.save }.not_to(change { Submission.count })
+          expect { subject.save }.not_to(change(Submission, :count))
         end
 
         it 'raises an error' do
@@ -203,7 +203,7 @@ RSpec.describe Submission, type: :model do
           params[:end_date] = Time.zone.today - 10
         end
         it 'does not persist model' do
-          expect { subject.save }.not_to(change { Submission.count })
+          expect { subject.save }.not_to(change(Submission, :count))
         end
 
         it 'raises an error' do

--- a/spec/models/submission_spec.rb
+++ b/spec/models/submission_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe Submission, type: :model do
     end
 
     it 'does not include standard model values' do
-      expect(as_json.keys).to_not include %w[id status created_at updated_at]
+      expect(as_json.keys).not_to include %w[id status created_at updated_at]
     end
   end
 

--- a/spec/models/submission_spec.rb
+++ b/spec/models/submission_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe Submission, type: :model do
     context 'with first name missing' do
       before { params.delete(:first_name) }
       it 'does not persist model' do
-        expect { subject.save }.not_to(change(Submission, :count))
+        expect { subject.save }.not_to(change(described_class, :count))
       end
 
       it 'raises an error' do
@@ -49,7 +49,7 @@ RSpec.describe Submission, type: :model do
     context 'with last name missing' do
       before { params.delete(:last_name) }
       it 'does not persist model' do
-        expect { subject.save }.not_to(change(Submission, :count))
+        expect { subject.save }.not_to(change(described_class, :count))
       end
 
       it 'raises an error' do
@@ -62,7 +62,7 @@ RSpec.describe Submission, type: :model do
       context 'with nino missing' do
         before { params.delete(:nino) }
         it 'does not persist model' do
-          expect { subject.save }.not_to(change(Submission, :count))
+          expect { subject.save }.not_to(change(described_class, :count))
         end
 
         it 'raises an error' do
@@ -74,7 +74,7 @@ RSpec.describe Submission, type: :model do
       context 'with an invalid nino' do
         before { params[:nino] = 'invalid_nino' }
         it 'does not persist model' do
-          expect { subject.save }.not_to(change(Submission, :count))
+          expect { subject.save }.not_to(change(described_class, :count))
         end
 
         it 'raises an error' do
@@ -88,7 +88,7 @@ RSpec.describe Submission, type: :model do
       context 'with dob missing' do
         before { params.delete(:dob) }
         it 'does not persist model' do
-          expect { subject.save }.not_to(change(Submission, :count))
+          expect { subject.save }.not_to(change(described_class, :count))
         end
 
         it 'raises an error' do
@@ -100,7 +100,7 @@ RSpec.describe Submission, type: :model do
       context 'with a badly formatted dob' do
         before { params[:dob] = 'date' }
         it 'does not persist model' do
-          expect { subject.save }.not_to(change(Submission, :count))
+          expect { subject.save }.not_to(change(described_class, :count))
         end
 
         it 'raises an error' do
@@ -112,7 +112,7 @@ RSpec.describe Submission, type: :model do
       context 'with a dob in the future' do
         before { params[:dob] = Time.zone.today + 1 }
         it 'does not persist model' do
-          expect { subject.save }.not_to(change(Submission, :count))
+          expect { subject.save }.not_to(change(described_class, :count))
         end
 
         it 'raises an error' do
@@ -126,7 +126,7 @@ RSpec.describe Submission, type: :model do
       context 'with start_date missing' do
         before { params.delete(:start_date) }
         it 'does not persist model' do
-          expect { subject.save }.not_to(change(Submission, :count))
+          expect { subject.save }.not_to(change(described_class, :count))
         end
 
         it 'raises an error' do
@@ -138,7 +138,7 @@ RSpec.describe Submission, type: :model do
       context 'with a badly formatted start_date' do
         before { params[:start_date] = 'date' }
         it 'does not persist model' do
-          expect { subject.save }.not_to(change(Submission, :count))
+          expect { subject.save }.not_to(change(described_class, :count))
         end
 
         it 'raises an error' do
@@ -150,7 +150,7 @@ RSpec.describe Submission, type: :model do
       context 'with a start_date in the future' do
         before { params[:start_date] = Time.zone.today + 1 }
         it 'does not persist model' do
-          expect { subject.save }.not_to(change(Submission, :count))
+          expect { subject.save }.not_to(change(described_class, :count))
         end
 
         it 'raises an error' do
@@ -164,7 +164,7 @@ RSpec.describe Submission, type: :model do
       context 'with end_date missing' do
         before { params.delete(:end_date) }
         it 'does not persist model' do
-          expect { subject.save }.not_to(change(Submission, :count))
+          expect { subject.save }.not_to(change(described_class, :count))
         end
 
         it 'raises an error' do
@@ -176,7 +176,7 @@ RSpec.describe Submission, type: :model do
       context 'with a badly formatted end_date' do
         before { params[:end_date] = 'date' }
         it 'does not persist model' do
-          expect { subject.save }.not_to(change(Submission, :count))
+          expect { subject.save }.not_to(change(described_class, :count))
         end
 
         it 'raises an error' do
@@ -188,7 +188,7 @@ RSpec.describe Submission, type: :model do
       context 'with an end_date in the future' do
         before { params[:end_date] = Time.zone.today + 1 }
         it 'does not persist model' do
-          expect { subject.save }.not_to(change(Submission, :count))
+          expect { subject.save }.not_to(change(described_class, :count))
         end
 
         it 'raises an error' do
@@ -203,7 +203,7 @@ RSpec.describe Submission, type: :model do
           params[:end_date] = Time.zone.today - 10
         end
         it 'does not persist model' do
-          expect { subject.save }.not_to(change(Submission, :count))
+          expect { subject.save }.not_to(change(described_class, :count))
         end
 
         it 'raises an error' do

--- a/spec/models/submission_spec.rb
+++ b/spec/models/submission_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Submission, type: :model do
   end
 
   it {
-    is_expected.to validate_inclusion_of(:use_case).in_array(%w[one two three four]).with_message(/Invalid use case/)
+    expect(submission).to validate_inclusion_of(:use_case).in_array(%w[one two three four]).with_message(/Invalid use case/)
   }
 
   describe '.as_json' do

--- a/spec/requests/api/v1/submissions_swagger_spec.rb
+++ b/spec/requests/api/v1/submissions_swagger_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe 'GET submission', type: :request, swagger_doc: 'v1/swagger.yaml' 
   let(:token) { application.access_tokens.create! }
   let(:Authorization) { "Bearer #{token.token}" }
 
-  context 'create' do
+  context 'when create is called' do
     let(:application) { dk_application }
     let(:use_case) { 'one' }
     let(:submission) do
@@ -130,7 +130,7 @@ RSpec.describe 'GET submission', type: :request, swagger_doc: 'v1/swagger.yaml' 
     end
   end
 
-  context 'result' do
+  context 'when result is called' do
     let(:application) { dk_application }
     let(:id) { submission.id }
 

--- a/spec/requests/smoke_test_swagger_spec.rb
+++ b/spec/requests/smoke_test_swagger_spec.rb
@@ -4,8 +4,13 @@ RSpec.describe 'smoke_test', type: :request, swagger_doc: 'v1/swagger.yaml' do
   let(:use_case) { 'one' }
 
   path '/smoke-test/{use_case}' do
-    before { allow_any_instance_of(SmokeTest).to receive(:call).and_return(success) }
+    let(:smoke_test) { instance_double(SmokeTest) }
     let(:success) { true }
+
+    before do
+      allow(SmokeTest).to receive(:new).and_return(smoke_test)
+      allow(smoke_test).to receive(:call).and_return(success)
+    end
 
     get('individual use_case smoke-test') do
       description 'Run a smoke test for chosen use_case'

--- a/spec/requests/status_controller_spec.rb
+++ b/spec/requests/status_controller_spec.rb
@@ -106,7 +106,7 @@ RSpec.describe StatusController, type: :request do
         }.to_json
       end
 
-      context 'dead set exists' do
+      context 'and dead set exists' do
         before do
           allow(Sidekiq::DeadSet).to receive(:new).and_return(instance_double(Sidekiq::DeadSet, size: 1))
           get '/health_check'
@@ -121,7 +121,7 @@ RSpec.describe StatusController, type: :request do
         end
       end
 
-      context 'retry set exists' do
+      context 'and retry set exists' do
         before do
           allow(Sidekiq::RetrySet).to receive(:new).and_return(instance_double(Sidekiq::RetrySet, size: 1))
           get '/health_check'

--- a/spec/requests/status_controller_spec.rb
+++ b/spec/requests/status_controller_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe StatusController, type: :request do
         allow(REDIS).to receive(:ping).and_raise(Redis::CannotConnectError)
         allow(Sidekiq::ProcessSet).to receive(:new).and_return(instance_double(Sidekiq::ProcessSet, size: 0))
 
-        connection = double('connection')
+        connection = instance_double('connection')
         allow(connection).to receive(:info).and_raise(Redis::CannotConnectError)
         allow(Sidekiq).to receive(:redis).and_yield(connection)
 

--- a/spec/services/bearer_token_spec.rb
+++ b/spec/services/bearer_token_spec.rb
@@ -16,7 +16,7 @@ describe BearerToken do
     it { expect { subject }.to raise_error 'Unsupported UseCase' }
   end
 
-  context 'UseCase one' do
+  context 'and UseCase one is passed' do
     let(:use_case) { 'use_case_one' }
     before do
       stub_request(:post, %r{\A#{Settings.credentials.use_case_one.host}/oauth/token\z})
@@ -35,7 +35,7 @@ describe BearerToken do
     end
   end
 
-  context 'UseCase two' do
+  context 'and UseCase two is passed' do
     let(:use_case) { 'use_case_two' }
     before do
       stub_request(:post, %r{\A#{Settings.credentials.use_case_two.host}/oauth/token\z})
@@ -49,7 +49,7 @@ describe BearerToken do
     end
   end
 
-  context 'UseCase three' do
+  context 'and UseCase three is passed' do
     let(:use_case) { 'use_case_three' }
     before do
       stub_request(:post, %r{\A#{Settings.credentials.use_case_three.host}/oauth/token\z})
@@ -63,7 +63,7 @@ describe BearerToken do
     end
   end
 
-  context 'UseCase four' do
+  context 'and UseCase four is passed' do
     let(:use_case) { 'use_case_four' }
     before do
       stub_request(:post, %r{\A#{Settings.credentials.use_case_four.host}/oauth/token\z})

--- a/spec/services/endpoint/tax_years_for_spec.rb
+++ b/spec/services/endpoint/tax_years_for_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Endpoint::TaxYearsFor do
     let(:date) { Date.new(2021, 4, 3) }
 
     it 'returns the previous year to the current year' do
-      is_expected.to eql '2020-21'
+      expect(tax_year).to eql '2020-21'
     end
   end
 
@@ -15,7 +15,7 @@ RSpec.describe Endpoint::TaxYearsFor do
     let(:date) { Date.new(2021, 5, 3) }
 
     it 'returns the current year to next year' do
-      is_expected.to eql '2021-22'
+      expect(tax_year).to eql '2021-22'
     end
   end
 end

--- a/spec/services/endpoint/uri_spec.rb
+++ b/spec/services/endpoint/uri_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Endpoint::Uri do
   let(:href) { '/root/type/sub?matchID=123456' }
   let(:from_date) { '2021-01-01' }
   let(:to_date) { '2021-03-31' }
-  it { is_expected.to be_a Endpoint::Uri }
+  it { is_expected.to be_a described_class }
 
   describe '.for_calling' do
     subject(:for_calling) { use_case.for_calling }

--- a/spec/services/queue_name_service_spec.rb
+++ b/spec/services/queue_name_service_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe QueueNameService do
         Settings.sentry.environment = 'uat'
         Settings.status.app_branch = 'this-is/a.test-branch'
       end
-      it 'should prefix the submission queue name with the branch name' do
+      it 'prefixes the submission queue name with the branch name' do
         expect(call).to eq 'this-is-a-test-branch-submissions'
       end
     end

--- a/spec/services/submission_service_spec.rb
+++ b/spec/services/submission_service_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe SubmissionService, vcr: { cassette_name: 'use_case_one_success' }
       end
     end
 
-    context 'RestClient::InternalServerError' do
+    context 'when the call fails with RestClient::InternalServerError' do
       before do
         allow(RestClient).to receive(:get).with(any_args).and_raise(RestClient::InternalServerError)
       end
@@ -76,7 +76,7 @@ RSpec.describe SubmissionService, vcr: { cassette_name: 'use_case_one_success' }
       end
     end
 
-    context 'RestClient::TooManyRequests' do
+    context 'when the call fails with RestClient::TooManyRequests' do
       before do
         call_count = 0
         allow(RestClient).to receive(:get).with(any_args) do

--- a/spec/services/use_case_spec.rb
+++ b/spec/services/use_case_spec.rb
@@ -16,8 +16,9 @@ RSpec.describe UseCase do
     end
 
     context 'when a valid bearer_token is not available' do
+      before { allow(BearerToken).to receive(:call).with('use_case_one').and_return('new_fake_token_value') }
+
       it 'calls BearerToken and stores the value in redis' do
-        expect(BearerToken).to receive(:call).with('use_case_one').and_return('new_fake_token_value')
         expect(REDIS.get('use_case_one_bearer_token')).to be nil
         subject
         expect(REDIS.get('use_case_one_bearer_token')).to eql 'new_fake_token_value'

--- a/spec/workers/submission_process_worker_spec.rb
+++ b/spec/workers/submission_process_worker_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe SubmissionProcessWorker do
           end
 
           it 'notifies sentry of the deadset addition' do
-            SubmissionProcessWorker.within_sidekiq_retries_exhausted_block do
+            described_class.within_sidekiq_retries_exhausted_block do
               expect(Sentry).to receive(:capture_message).with(expected_message)
             end
           end

--- a/spec/workers/submission_process_worker_spec.rb
+++ b/spec/workers/submission_process_worker_spec.rb
@@ -3,11 +3,11 @@ require 'rails_helper'
 RSpec.describe SubmissionProcessWorker do
   include AuthorisedRequestHelper
 
+  subject { worker.perform(submission.id) }
+
   let(:worker) { described_class.new }
   let(:application) { dk_application }
   let(:submission) { create :submission, oauth_application: application }
-
-  subject { worker.perform(submission.id) }
 
   before do
     allow(Submission).to receive(:find).with(submission.id).and_return(submission)


### PR DESCRIPTION
## What

Remove the follow cops from the rubocop_todo file:
* RSpec/LeadingSubject
* RSpec/NotToNot
* RSpec/StubbedMock
* RSpec/VerifiedDoubles
* Style/BlockDelimiters
* RSpec/ImplicitSubject
* RSpec/ExpectChange
* RSpec/ExampleWording
* Layout/AccessModifierIndentation (auto-correct)
* RSpec/AnyInstance
* RSpec/ContextWording ( 1 remains but the govuk allowed words don't match - I'll raise a PR and see what happens)
* RSpec/DescribedClass (auto-correct)

And make the required changes where necessary

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
- You should have run `NOCOVERAGE=true rake rswag` to ensure the swagger docs are up-to-date
