### PR TITLE
Fix: Rubocop updates

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -38,14 +38,6 @@ RSpec/EmptyExampleGroup:
     - 'spec/requests/api/v1/use_case_swagger_spec.rb'
     - 'spec/requests/smoke_test_swagger_spec.rb'
 
-# Offense count: 1
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyle.
-# SupportedStyles: implicit, each, example
-RSpec/HookArgument:
-  Exclude:
-    - 'spec/spec_helper.rb'
-
 # Offense count: 6
 # Configuration parameters: AssignmentOnly.
 RSpec/InstanceVariable:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -38,16 +38,6 @@ RSpec/EmptyExampleGroup:
     - 'spec/requests/api/v1/use_case_swagger_spec.rb'
     - 'spec/requests/smoke_test_swagger_spec.rb'
 
-# Offense count: 23
-# Cop supports --auto-correct.
-RSpec/EmptyLineAfterHook:
-  Exclude:
-    - 'spec/models/submission_spec.rb'
-    - 'spec/requests/api/v1/submissions_swagger_spec.rb'
-    - 'spec/requests/api/v1/use_case_swagger_spec.rb'
-    - 'spec/requests/smoke_test_swagger_spec.rb'
-    - 'spec/services/queue_name_service_spec.rb'
-
 # Offense count: 8
 # Cop supports --auto-correct.
 RSpec/EmptyLineAfterSubject:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -38,14 +38,6 @@ RSpec/EmptyExampleGroup:
     - 'spec/requests/api/v1/use_case_swagger_spec.rb'
     - 'spec/requests/smoke_test_swagger_spec.rb'
 
-# Offense count: 7
-# Cop supports --auto-correct.
-RSpec/EmptyLineAfterFinalLet:
-  Exclude:
-    - 'spec/requests/api/v1/submissions_swagger_spec.rb'
-    - 'spec/services/bearer_token_spec.rb'
-    - 'spec/services/endpoint/uri_spec.rb'
-
 # Offense count: 23
 # Cop supports --auto-correct.
 RSpec/EmptyLineAfterHook:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -31,6 +31,7 @@ RSpec/ContextWording:
     - 'spec/workers/submission_process_worker_spec.rb'
 
 # Offense count: 6
+# leaving this in play for now - Swagger does not trip the expected structure for Rspec
 RSpec/EmptyExampleGroup:
   Exclude:
     - 'spec/requests/api/v1/submissions_swagger_spec.rb'

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -37,12 +37,6 @@ RSpec/EmptyExampleGroup:
     - 'spec/requests/api/v1/use_case_swagger_spec.rb'
     - 'spec/requests/smoke_test_swagger_spec.rb'
 
-# Offense count: 1
-# Cop supports --auto-correct.
-RSpec/EmptyLineAfterExampleGroup:
-  Exclude:
-    - 'spec/services/hmrc/sandbox/create_test_data_spec.rb'
-
 # Offense count: 7
 # Cop supports --auto-correct.
 RSpec/EmptyLineAfterFinalLet:
@@ -50,7 +44,6 @@ RSpec/EmptyLineAfterFinalLet:
     - 'spec/requests/api/v1/submissions_swagger_spec.rb'
     - 'spec/services/bearer_token_spec.rb'
     - 'spec/services/endpoint/uri_spec.rb'
-    - 'spec/services/hmrc/sandbox/create_test_data_spec.rb'
 
 # Offense count: 23
 # Cop supports --auto-correct.
@@ -69,7 +62,6 @@ RSpec/EmptyLineAfterSubject:
     - 'spec/services/bearer_token_spec.rb'
     - 'spec/services/endpoint/headers_spec.rb'
     - 'spec/services/endpoint/uri_spec.rb'
-    - 'spec/services/hmrc/sandbox/create_test_data_spec.rb'
     - 'spec/services/smoke_test_spec.rb'
     - 'spec/services/submission_service_spec.rb'
     - 'spec/services/use_case_spec.rb'
@@ -96,7 +88,6 @@ RSpec/NamedSubject:
   Exclude:
     - 'spec/models/submission_spec.rb'
     - 'spec/services/bearer_token_spec.rb'
-    - 'spec/services/hmrc/sandbox/create_test_data_spec.rb'
     - 'spec/services/submission_service_spec.rb'
     - 'spec/services/use_case_spec.rb'
     - 'spec/workers/submission_process_worker_spec.rb'

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -38,17 +38,6 @@ RSpec/EmptyExampleGroup:
     - 'spec/requests/api/v1/use_case_swagger_spec.rb'
     - 'spec/requests/smoke_test_swagger_spec.rb'
 
-# Offense count: 8
-# Cop supports --auto-correct.
-RSpec/EmptyLineAfterSubject:
-  Exclude:
-    - 'spec/services/bearer_token_spec.rb'
-    - 'spec/services/endpoint/headers_spec.rb'
-    - 'spec/services/endpoint/uri_spec.rb'
-    - 'spec/services/smoke_test_spec.rb'
-    - 'spec/services/submission_service_spec.rb'
-    - 'spec/services/use_case_spec.rb'
-
 # Offense count: 1
 # Cop supports --auto-correct.
 # Configuration parameters: EnforcedStyle.

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -46,16 +46,6 @@ RSpec/InstanceVariable:
     - 'spec/services/hmrc/sandbox/create_test_data_spec.rb'
     - 'spec/services/submission_service_spec.rb'
 
-# Offense count: 62
-# Configuration parameters: IgnoreSharedExamples.
-RSpec/NamedSubject:
-  Exclude:
-    - 'spec/models/submission_spec.rb'
-    - 'spec/services/bearer_token_spec.rb'
-    - 'spec/services/submission_service_spec.rb'
-    - 'spec/services/use_case_spec.rb'
-    - 'spec/workers/submission_process_worker_spec.rb'
-
 # Offense count: 14
 RSpec/ScatteredSetup:
   Exclude:

--- a/spec/models/submission_spec.rb
+++ b/spec/models/submission_spec.rb
@@ -36,6 +36,7 @@ RSpec.describe Submission, type: :model do
   describe '#save' do
     context 'with first name missing' do
       before { params.delete(:first_name) }
+
       it 'does not persist model' do
         expect { subject.save }.not_to(change(described_class, :count))
       end
@@ -48,6 +49,7 @@ RSpec.describe Submission, type: :model do
 
     context 'with last name missing' do
       before { params.delete(:last_name) }
+
       it 'does not persist model' do
         expect { subject.save }.not_to(change(described_class, :count))
       end
@@ -61,6 +63,7 @@ RSpec.describe Submission, type: :model do
     context 'with nino errors' do
       context 'with nino missing' do
         before { params.delete(:nino) }
+
         it 'does not persist model' do
           expect { subject.save }.not_to(change(described_class, :count))
         end
@@ -73,6 +76,7 @@ RSpec.describe Submission, type: :model do
 
       context 'with an invalid nino' do
         before { params[:nino] = 'invalid_nino' }
+
         it 'does not persist model' do
           expect { subject.save }.not_to(change(described_class, :count))
         end
@@ -87,6 +91,7 @@ RSpec.describe Submission, type: :model do
     context 'with dob errors' do
       context 'with dob missing' do
         before { params.delete(:dob) }
+
         it 'does not persist model' do
           expect { subject.save }.not_to(change(described_class, :count))
         end
@@ -99,6 +104,7 @@ RSpec.describe Submission, type: :model do
 
       context 'with a badly formatted dob' do
         before { params[:dob] = 'date' }
+
         it 'does not persist model' do
           expect { subject.save }.not_to(change(described_class, :count))
         end
@@ -111,6 +117,7 @@ RSpec.describe Submission, type: :model do
 
       context 'with a dob in the future' do
         before { params[:dob] = Time.zone.today + 1 }
+
         it 'does not persist model' do
           expect { subject.save }.not_to(change(described_class, :count))
         end
@@ -125,6 +132,7 @@ RSpec.describe Submission, type: :model do
     context 'with start_date errors' do
       context 'with start_date missing' do
         before { params.delete(:start_date) }
+
         it 'does not persist model' do
           expect { subject.save }.not_to(change(described_class, :count))
         end
@@ -137,6 +145,7 @@ RSpec.describe Submission, type: :model do
 
       context 'with a badly formatted start_date' do
         before { params[:start_date] = 'date' }
+
         it 'does not persist model' do
           expect { subject.save }.not_to(change(described_class, :count))
         end
@@ -149,6 +158,7 @@ RSpec.describe Submission, type: :model do
 
       context 'with a start_date in the future' do
         before { params[:start_date] = Time.zone.today + 1 }
+
         it 'does not persist model' do
           expect { subject.save }.not_to(change(described_class, :count))
         end
@@ -163,6 +173,7 @@ RSpec.describe Submission, type: :model do
     context 'with end_date errors' do
       context 'with end_date missing' do
         before { params.delete(:end_date) }
+
         it 'does not persist model' do
           expect { subject.save }.not_to(change(described_class, :count))
         end
@@ -175,6 +186,7 @@ RSpec.describe Submission, type: :model do
 
       context 'with a badly formatted end_date' do
         before { params[:end_date] = 'date' }
+
         it 'does not persist model' do
           expect { subject.save }.not_to(change(described_class, :count))
         end
@@ -187,6 +199,7 @@ RSpec.describe Submission, type: :model do
 
       context 'with an end_date in the future' do
         before { params[:end_date] = Time.zone.today + 1 }
+
         it 'does not persist model' do
           expect { subject.save }.not_to(change(described_class, :count))
         end
@@ -202,6 +215,7 @@ RSpec.describe Submission, type: :model do
           params[:start_date] = Time.zone.today - 9
           params[:end_date] = Time.zone.today - 10
         end
+
         it 'does not persist model' do
           expect { subject.save }.not_to(change(described_class, :count))
         end

--- a/spec/models/submission_spec.rb
+++ b/spec/models/submission_spec.rb
@@ -38,12 +38,12 @@ RSpec.describe Submission, type: :model do
       before { params.delete(:first_name) }
 
       it 'does not persist model' do
-        expect { subject.save }.not_to(change(described_class, :count))
+        expect { submission.save }.not_to(change(described_class, :count))
       end
 
       it 'raises an error' do
-        subject.save
-        expect(subject.errors.full_messages).to include("First name can't be blank")
+        submission.save
+        expect(submission.errors.full_messages).to include("First name can't be blank")
       end
     end
 
@@ -51,12 +51,12 @@ RSpec.describe Submission, type: :model do
       before { params.delete(:last_name) }
 
       it 'does not persist model' do
-        expect { subject.save }.not_to(change(described_class, :count))
+        expect { submission.save }.not_to(change(described_class, :count))
       end
 
       it 'raises an error' do
-        subject.save
-        expect(subject.errors.full_messages).to include("Last name can't be blank")
+        submission.save
+        expect(submission.errors.full_messages).to include("Last name can't be blank")
       end
     end
 
@@ -65,12 +65,12 @@ RSpec.describe Submission, type: :model do
         before { params.delete(:nino) }
 
         it 'does not persist model' do
-          expect { subject.save }.not_to(change(described_class, :count))
+          expect { submission.save }.not_to(change(described_class, :count))
         end
 
         it 'raises an error' do
-          subject.save
-          expect(subject.errors.full_messages).to include('Nino is not valid')
+          submission.save
+          expect(submission.errors.full_messages).to include('Nino is not valid')
         end
       end
 
@@ -78,12 +78,12 @@ RSpec.describe Submission, type: :model do
         before { params[:nino] = 'invalid_nino' }
 
         it 'does not persist model' do
-          expect { subject.save }.not_to(change(described_class, :count))
+          expect { submission.save }.not_to(change(described_class, :count))
         end
 
         it 'raises an error' do
-          subject.save
-          expect(subject.errors.full_messages).to include('Nino is not valid')
+          submission.save
+          expect(submission.errors.full_messages).to include('Nino is not valid')
         end
       end
     end
@@ -93,12 +93,12 @@ RSpec.describe Submission, type: :model do
         before { params.delete(:dob) }
 
         it 'does not persist model' do
-          expect { subject.save }.not_to(change(described_class, :count))
+          expect { submission.save }.not_to(change(described_class, :count))
         end
 
         it 'raises an error' do
-          subject.save
-          expect(subject.errors.full_messages).to include('Dob is not a valid date')
+          submission.save
+          expect(submission.errors.full_messages).to include('Dob is not a valid date')
         end
       end
 
@@ -106,12 +106,12 @@ RSpec.describe Submission, type: :model do
         before { params[:dob] = 'date' }
 
         it 'does not persist model' do
-          expect { subject.save }.not_to(change(described_class, :count))
+          expect { submission.save }.not_to(change(described_class, :count))
         end
 
         it 'raises an error' do
-          subject.save
-          expect(subject.errors.full_messages).to include('Dob is not a valid date')
+          submission.save
+          expect(submission.errors.full_messages).to include('Dob is not a valid date')
         end
       end
 
@@ -119,12 +119,12 @@ RSpec.describe Submission, type: :model do
         before { params[:dob] = Time.zone.today + 1 }
 
         it 'does not persist model' do
-          expect { subject.save }.not_to(change(described_class, :count))
+          expect { submission.save }.not_to(change(described_class, :count))
         end
 
         it 'raises an error' do
-          subject.save
-          expect(subject.errors.full_messages).to include('Dob is not a valid date')
+          submission.save
+          expect(submission.errors.full_messages).to include('Dob is not a valid date')
         end
       end
     end
@@ -134,12 +134,12 @@ RSpec.describe Submission, type: :model do
         before { params.delete(:start_date) }
 
         it 'does not persist model' do
-          expect { subject.save }.not_to(change(described_class, :count))
+          expect { submission.save }.not_to(change(described_class, :count))
         end
 
         it 'raises an error' do
-          subject.save
-          expect(subject.errors.full_messages).to include('Start date is not a valid date')
+          submission.save
+          expect(submission.errors.full_messages).to include('Start date is not a valid date')
         end
       end
 
@@ -147,12 +147,12 @@ RSpec.describe Submission, type: :model do
         before { params[:start_date] = 'date' }
 
         it 'does not persist model' do
-          expect { subject.save }.not_to(change(described_class, :count))
+          expect { submission.save }.not_to(change(described_class, :count))
         end
 
         it 'raises an error' do
-          subject.save
-          expect(subject.errors.full_messages).to include('Start date is not a valid date')
+          submission.save
+          expect(submission.errors.full_messages).to include('Start date is not a valid date')
         end
       end
 
@@ -160,12 +160,12 @@ RSpec.describe Submission, type: :model do
         before { params[:start_date] = Time.zone.today + 1 }
 
         it 'does not persist model' do
-          expect { subject.save }.not_to(change(described_class, :count))
+          expect { submission.save }.not_to(change(described_class, :count))
         end
 
         it 'raises an error' do
-          subject.save
-          expect(subject.errors.full_messages).to include('Start date is not a valid date')
+          submission.save
+          expect(submission.errors.full_messages).to include('Start date is not a valid date')
         end
       end
     end
@@ -175,12 +175,12 @@ RSpec.describe Submission, type: :model do
         before { params.delete(:end_date) }
 
         it 'does not persist model' do
-          expect { subject.save }.not_to(change(described_class, :count))
+          expect { submission.save }.not_to(change(described_class, :count))
         end
 
         it 'raises an error' do
-          subject.save
-          expect(subject.errors.full_messages).to include('End date is not a valid date')
+          submission.save
+          expect(submission.errors.full_messages).to include('End date is not a valid date')
         end
       end
 
@@ -188,12 +188,12 @@ RSpec.describe Submission, type: :model do
         before { params[:end_date] = 'date' }
 
         it 'does not persist model' do
-          expect { subject.save }.not_to(change(described_class, :count))
+          expect { submission.save }.not_to(change(described_class, :count))
         end
 
         it 'raises an error' do
-          subject.save
-          expect(subject.errors.full_messages).to include('End date is not a valid date')
+          submission.save
+          expect(submission.errors.full_messages).to include('End date is not a valid date')
         end
       end
 
@@ -201,12 +201,12 @@ RSpec.describe Submission, type: :model do
         before { params[:end_date] = Time.zone.today + 1 }
 
         it 'does not persist model' do
-          expect { subject.save }.not_to(change(described_class, :count))
+          expect { submission.save }.not_to(change(described_class, :count))
         end
 
         it 'raises an error' do
-          subject.save
-          expect(subject.errors.full_messages).to include('End date is not a valid date')
+          submission.save
+          expect(submission.errors.full_messages).to include('End date is not a valid date')
         end
       end
 
@@ -217,13 +217,13 @@ RSpec.describe Submission, type: :model do
         end
 
         it 'does not persist model' do
-          expect { subject.save }.not_to(change(described_class, :count))
+          expect { submission.save }.not_to(change(described_class, :count))
         end
 
         it 'raises an error' do
-          subject.save
-          expect(subject.errors.full_messages).to include('Start date is not a valid date',
-                                                          'End date is not a valid date')
+          submission.save
+          expect(submission.errors.full_messages).to include('Start date is not a valid date',
+                                                             'End date is not a valid date')
         end
       end
     end

--- a/spec/requests/api/v1/submissions_swagger_spec.rb
+++ b/spec/requests/api/v1/submissions_swagger_spec.rb
@@ -64,6 +64,7 @@ RSpec.describe 'GET submission', type: :request, swagger_doc: 'v1/swagger.yaml' 
               }
             }
           end
+
           run_test! do |response|
             expect(response.media_type).to eq('application/json')
             expect(response.body).to match(/id/)

--- a/spec/requests/api/v1/submissions_swagger_spec.rb
+++ b/spec/requests/api/v1/submissions_swagger_spec.rb
@@ -23,6 +23,7 @@ RSpec.describe 'GET submission', type: :request, swagger_doc: 'v1/swagger.yaml' 
         }
       }
     end
+
     path '/api/v1/submission/create/{use_case}' do
       post('Create new submission') do
         tags 'Submissions'

--- a/spec/requests/smoke_test_swagger_spec.rb
+++ b/spec/requests/smoke_test_swagger_spec.rb
@@ -42,6 +42,7 @@ RSpec.describe 'smoke_test', type: :request, swagger_doc: 'v1/swagger.yaml' do
       allow(REDIS).to receive(:get).with('smoke-test-three').and_return(true)
       allow(REDIS).to receive(:get).with('smoke-test-four').and_return(true)
     end
+
     let(:test_one_result) { true }
 
     get('call smoke_test') do

--- a/spec/services/bearer_token_spec.rb
+++ b/spec/services/bearer_token_spec.rb
@@ -14,7 +14,7 @@ describe BearerToken do
   context 'when called with an invalid use_case' do
     subject(:bearer_token) { described_class.new('not_a_use_case') }
 
-    it { expect { subject }.to raise_error 'Unsupported UseCase' }
+    it { expect { bearer_token }.to raise_error 'Unsupported UseCase' }
   end
 
   context 'and UseCase one is passed' do

--- a/spec/services/bearer_token_spec.rb
+++ b/spec/services/bearer_token_spec.rb
@@ -2,6 +2,7 @@ require 'rails_helper'
 
 describe BearerToken do
   subject(:bearer_token) { described_class.new(use_case) }
+
   let(:fake_data) do
     {
       access_token: 'zz00000z00z0z00000z0z0z0000z0000',
@@ -32,6 +33,7 @@ describe BearerToken do
 
     describe '.call' do
       subject(:call) { described_class.call('use_case_one') }
+
       it { is_expected.to eql 'zz00000z00z0z00000z0z0z0000z0000' }
     end
   end

--- a/spec/services/bearer_token_spec.rb
+++ b/spec/services/bearer_token_spec.rb
@@ -18,6 +18,7 @@ describe BearerToken do
 
   context 'and UseCase one is passed' do
     let(:use_case) { 'use_case_one' }
+
     before do
       stub_request(:post, %r{\A#{Settings.credentials.use_case_one.host}/oauth/token\z})
         .to_return(status: 200, body: fake_data)
@@ -37,6 +38,7 @@ describe BearerToken do
 
   context 'and UseCase two is passed' do
     let(:use_case) { 'use_case_two' }
+
     before do
       stub_request(:post, %r{\A#{Settings.credentials.use_case_two.host}/oauth/token\z})
         .to_return(status: 200, body: fake_data)
@@ -51,6 +53,7 @@ describe BearerToken do
 
   context 'and UseCase three is passed' do
     let(:use_case) { 'use_case_three' }
+
     before do
       stub_request(:post, %r{\A#{Settings.credentials.use_case_three.host}/oauth/token\z})
         .to_return(status: 200, body: fake_data)
@@ -65,6 +68,7 @@ describe BearerToken do
 
   context 'and UseCase four is passed' do
     let(:use_case) { 'use_case_four' }
+
     before do
       stub_request(:post, %r{\A#{Settings.credentials.use_case_four.host}/oauth/token\z})
         .to_return(status: 200, body: fake_data)

--- a/spec/services/endpoint/headers_spec.rb
+++ b/spec/services/endpoint/headers_spec.rb
@@ -2,6 +2,7 @@ require 'rails_helper'
 
 RSpec.describe Endpoint::Headers do
   subject(:headers) { described_class.new(href, correlation_id, token) }
+
   let(:correlation_id) { 'fake-correlation_id' }
   let(:token) { 'fake_bearer_token' }
 

--- a/spec/services/endpoint/uri_spec.rb
+++ b/spec/services/endpoint/uri_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe Endpoint::Uri do
   let(:href) { '/root/type/sub?matchID=123456' }
   let(:from_date) { '2021-01-01' }
   let(:to_date) { '2021-03-31' }
+
   it { is_expected.to be_a described_class }
 
   describe '.for_calling' do

--- a/spec/services/endpoint/uri_spec.rb
+++ b/spec/services/endpoint/uri_spec.rb
@@ -2,6 +2,7 @@ require 'rails_helper'
 
 RSpec.describe Endpoint::Uri do
   subject(:use_case) { described_class.new(href, use_case: 'use_case_one', from_date:, to_date:) }
+
   let(:href) { '/root/type/sub?matchID=123456' }
   let(:from_date) { '2021-01-01' }
   let(:to_date) { '2021-03-31' }

--- a/spec/services/hmrc/sandbox/create_test_data_spec.rb
+++ b/spec/services/hmrc/sandbox/create_test_data_spec.rb
@@ -4,6 +4,7 @@ describe HMRC::Sandbox::CreateTestData do
   subject(:create_data) { described_class.new(type) }
 
   let(:type) { :paye }
+
   before do
     remove_request_stub(@hmrc_stub_requests)
     allow(REDIS).to receive(:get).with('use_case_one_bearer_token').and_return('dummy_bearer_token')
@@ -21,6 +22,7 @@ describe HMRC::Sandbox::CreateTestData do
 
   describe '#call' do
     subject(:call) { described_class.call(type, '2021-01-01', '2021-02-01') }
+
     let(:type) { :employment }
 
     it 'makes a single post to the expected endpoint' do
@@ -28,15 +30,16 @@ describe HMRC::Sandbox::CreateTestData do
       expect(a_request(:post, /\A#{Settings.credentials.host}.*#{type}.*\z/)).to have_been_made.times(1)
     end
   end
+
   context 'when called on production' do
     before { allow(Settings).to receive(:environment).and_return('production') }
 
-    it { expect { subject }.to raise_error HMRC::Sandbox::ProductionError }
+    it { expect { create_data }.to raise_error HMRC::Sandbox::ProductionError }
   end
 
   context 'when the type is invalid' do
     let(:type) { :tax_credit }
 
-    it { expect { subject }.to raise_error HMRC::Sandbox::TypeError }
+    it { expect { create_data }.to raise_error HMRC::Sandbox::TypeError }
   end
 end

--- a/spec/services/queue_name_service_spec.rb
+++ b/spec/services/queue_name_service_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe QueueNameService do
         Settings.sentry.environment = 'uat'
         Settings.status.app_branch = 'this-is/a.test-branch'
       end
+
       it 'prefixes the submission queue name with the branch name' do
         expect(call).to eq 'this-is-a-test-branch-submissions'
       end
@@ -18,6 +19,7 @@ RSpec.describe QueueNameService do
       before do
         Settings.sentry.environment = 'test'
       end
+
       it 'sets the submission queue name to /submissions/' do
         expect(call).to eq 'submissions'
       end

--- a/spec/services/smoke_test_spec.rb
+++ b/spec/services/smoke_test_spec.rb
@@ -2,6 +2,7 @@ require 'rails_helper'
 
 RSpec.describe SmokeTest, :smoke_test do
   subject(:use_case) { described_class.call(:one) }
+
   let(:expected_response) { File.read('./spec/fixtures/smoke_tests/use_case_one.json') }
 
   before { WebMock.disable! }

--- a/spec/services/submission_service_spec.rb
+++ b/spec/services/submission_service_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe SubmissionService, vcr: { cassette_name: 'use_case_one_success' }
 
   describe '.call' do
     subject(:call) { described_class.call(submission) }
+
     let(:submission) { create :submission, data }
     let(:application) { dk_application }
     let(:data) do

--- a/spec/services/submission_service_spec.rb
+++ b/spec/services/submission_service_spec.rb
@@ -27,21 +27,21 @@ RSpec.describe SubmissionService, vcr: { cassette_name: 'use_case_one_success' }
     end
 
     it 'adds a result attachment to the submission' do
-      expect { subject }.to change(ActiveStorage::Attachment, :count).by(1)
+      expect { call }.to change(ActiveStorage::Attachment, :count).by(1)
     end
 
     it 'gives the submission result attachment the a filename' do
-      subject
+      call
       expect(submission.result.filename).to eq "#{submission.id}.json"
     end
 
     it 'gives the submission result attachment a key' do
-      subject
+      call
       expect(submission.result.key).to eq "submission/result/#{submission.id}"
     end
 
     it 'gives the submission result attachment a content type' do
-      subject
+      call
       expect(submission.result.content_type).to eq 'application/json'
     end
 
@@ -61,7 +61,7 @@ RSpec.describe SubmissionService, vcr: { cassette_name: 'use_case_one_success' }
       end
 
       it 'raises an error and records the error in the result' do
-        expect { subject }.to raise_error Errors::CitizenDetailsMismatchError, 'User details not matched'
+        expect { call }.to raise_error Errors::CitizenDetailsMismatchError, 'User details not matched'
         expect(submission.result.blob.download).to match(/submitted client details could not be found in HMRC service/)
       end
     end
@@ -72,7 +72,7 @@ RSpec.describe SubmissionService, vcr: { cassette_name: 'use_case_one_success' }
       end
 
       it 'adds a result attachment detailing the error' do
-        subject
+        call
         expect(submission.result.blob.download).to match(/returned INTERNAL_SERVER_ERROR/)
       end
     end
@@ -92,16 +92,16 @@ RSpec.describe SubmissionService, vcr: { cassette_name: 'use_case_one_success' }
 
       it 'logs that rate limiting occurred' do
         allow(Rails.logger).to receive(:info).at_least(:once)
-        subject
+        call
         expect(Rails.logger).to have_received(:info).with(/Rate limited while calling/).once
       end
 
       it 'adds a result attachment to the submission' do
-        expect { subject }.to change(ActiveStorage::Attachment, :count).by(1)
+        expect { call }.to change(ActiveStorage::Attachment, :count).by(1)
       end
 
       it 'does not add a result attachment detailing an error' do
-        subject
+        call
         expect(submission.result.blob.download).not_to match(/ERROR/)
       end
     end

--- a/spec/services/use_case_spec.rb
+++ b/spec/services/use_case_spec.rb
@@ -28,6 +28,7 @@ RSpec.describe UseCase do
 
   describe '.host' do
     subject(:host) { use_case.host }
+
     before do
       REDIS.set('use_case_one_bearer_token', 'fake_token_value')
       subject

--- a/spec/services/use_case_spec.rb
+++ b/spec/services/use_case_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe UseCase do
     context 'when a valid bearer_token is available' do
       before do
         REDIS.set('use_case_one_bearer_token', 'fake_token_value')
-        subject
+        use_case
       end
 
       it 'does not call the bearer_token generator' do
@@ -20,7 +20,7 @@ RSpec.describe UseCase do
 
       it 'calls BearerToken and stores the value in redis' do
         expect(REDIS.get('use_case_one_bearer_token')).to be nil
-        subject
+        use_case
         expect(REDIS.get('use_case_one_bearer_token')).to eql 'new_fake_token_value'
       end
     end
@@ -31,7 +31,7 @@ RSpec.describe UseCase do
 
     before do
       REDIS.set('use_case_one_bearer_token', 'fake_token_value')
-      subject
+      host
     end
 
     it { is_expected.to eql Settings.credentials.use_case_one.host }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -65,7 +65,7 @@ RSpec.configure do |config|
     @hmrc_stub_requests = stub_request(:post, %r{\A#{Settings.credentials.host}/.*\z}).to_return(status: 200, body: '')
   end
 
-  config.before(:each) do
+  config.before do
     REDIS.flushdb
   end
 

--- a/spec/workers/submission_process_worker_spec.rb
+++ b/spec/workers/submission_process_worker_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe SubmissionProcessWorker do
   include AuthorisedRequestHelper
 
-  subject { worker.perform(submission.id) }
+  subject(:submission_process_worker) { worker.perform(submission.id) }
 
   let(:worker) { described_class.new }
   let(:application) { dk_application }
@@ -17,11 +17,11 @@ RSpec.describe SubmissionProcessWorker do
   describe '.perform' do
     it 'calls SubmissionService' do
       expect(SubmissionService).to receive(:call)
-      subject
+      submission_process_worker
     end
 
     it 'updates the submission status' do
-      subject
+      submission_process_worker
       expect(submission.status).to eq('completed')
     end
 
@@ -33,7 +33,7 @@ RSpec.describe SubmissionProcessWorker do
         end
 
         it 'updates the submission status amd records the error ' do
-          subject
+          submission_process_worker
           expect(submission.status).to eq('failed')
         end
       end
@@ -47,7 +47,7 @@ RSpec.describe SubmissionProcessWorker do
           before { worker.retry_count = 2 }
 
           it 'raises a not tracked error and leaves the status' do
-            expect { subject }.to raise_error Errors::SentryIgnoresThisSidekiqFailError
+            expect { submission_process_worker }.to raise_error Errors::SentryIgnoresThisSidekiqFailError
             expect(submission.status).to eq 'processing'
           end
         end
@@ -58,7 +58,7 @@ RSpec.describe SubmissionProcessWorker do
           before { worker.retry_count = 3 }
 
           it 'updates the submission status' do
-            expect { subject }.to raise_error StandardError, 'A problem occurred'
+            expect { submission_process_worker }.to raise_error StandardError, 'A problem occurred'
             expect(submission.status).to eq('failed')
           end
 


### PR DESCRIPTION
## What

Update more rubocop_todo:
* RSpec/EmptyLineAfterExampleGroup
* RSpec/NamedSubject
* RSpec/EmptyLineAfterFinalLet - ran autocorrect
* RSpec/EmptyLineAfterHook - ran autocorrect
* RSpec/EmptyLineAfterSubject - ran autocorrect
* RSpec/HookArgument - ran autocorrect

Added comment to RSpec/EmptyExampleGroup because swagger is clashing with the expected syntax of Rspec

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
- You should have run `NOCOVERAGE=true rake rswag` to ensure the swagger docs are up-to-date
