### PR TITLE
Fix/rubocop todos

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -27,10 +27,3 @@ RSpec/VariableName:
   EnforcedStyle: snake_case
   Exclude:
     - 'spec/requests/api/v1/submissions_swagger_spec.rb'
-
-# Offense count: 67
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyleForMultiline.
-# SupportedStylesForMultiline: comma, consistent_comma, no_comma
-Style/TrailingCommaInHashLiteral:
-  Enabled: false

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -28,13 +28,6 @@ RSpec/VariableName:
   Exclude:
     - 'spec/requests/api/v1/submissions_swagger_spec.rb'
 
-# Offense count: 746
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyle, ConsistentQuotesInMultiline.
-# SupportedStyles: single_quotes, double_quotes
-Style/StringLiterals:
-  Enabled: false
-
 # Offense count: 67
 # Cop supports --auto-correct.
 # Configuration parameters: EnforcedStyleForMultiline.

--- a/Gemfile
+++ b/Gemfile
@@ -1,60 +1,60 @@
-source 'https://rubygems.org'
+source "https://rubygems.org"
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-ruby '3.1.0'
+ruby "3.1.0"
 
-gem 'aws-sdk-s3', require: false
-gem 'bootsnap', '>= 1.4.4', require: false
-gem 'config'
-gem 'doorkeeper'
-gem 'dotenv-rails'
-gem 'net-imap'
-gem 'net-pop'
-gem 'net-smtp'
-gem 'pg', '~> 1.3'
-gem 'puma', '~> 5.6'
-gem 'rails', '~> 6.1.4'
-gem 'redis'
-gem 'redis-namespace'
-gem 'rest-client'
-gem 'rotp'
-gem 'rswag-api'
-gem 'rswag-ui'
-gem 'sentry-rails'
-gem 'sentry-ruby'
-gem 'sidekiq'
-gem 'timeliness-i18n'
-gem 'validates_timeliness', '~> 6.0.0.beta2'
+gem "aws-sdk-s3", require: false
+gem "bootsnap", ">= 1.4.4", require: false
+gem "config"
+gem "doorkeeper"
+gem "dotenv-rails"
+gem "net-imap"
+gem "net-pop"
+gem "net-smtp"
+gem "pg", "~> 1.3"
+gem "puma", "~> 5.6"
+gem "rails", "~> 6.1.4"
+gem "redis"
+gem "redis-namespace"
+gem "rest-client"
+gem "rotp"
+gem "rswag-api"
+gem "rswag-ui"
+gem "sentry-rails"
+gem "sentry-ruby"
+gem "sidekiq"
+gem "timeliness-i18n"
+gem "validates_timeliness", "~> 6.0.0.beta2"
 
 group :development, :test do
-  gem 'byebug'
-  gem 'factory_bot_rails', '>= 5.2.0'
-  gem 'faker', '>=1.9.1'
-  gem 'guard-livereload'
-  gem 'guard-rspec'
-  gem 'guard-rubocop'
-  gem 'highline'
-  gem 'pry-byebug'
-  gem 'rspec_junit_formatter'
-  gem 'rswag-specs'
-  gem 'rubocop-govuk', require: false
-  gem 'rubocop-performance'
+  gem "byebug"
+  gem "factory_bot_rails", ">= 5.2.0"
+  gem "faker", ">=1.9.1"
+  gem "guard-livereload"
+  gem "guard-rspec"
+  gem "guard-rubocop"
+  gem "highline"
+  gem "pry-byebug"
+  gem "rspec_junit_formatter"
+  gem "rswag-specs"
+  gem "rubocop-govuk", require: false
+  gem "rubocop-performance"
 end
 
 group :test do
-  gem 'mock_redis'
-  gem 'rspec-rails', '~> 5.1'
-  gem 'rspec-sidekiq'
-  gem 'shoulda-matchers'
-  gem 'simplecov', require: false
-  gem 'simplecov-rcov'
-  gem 'vcr'
-  gem 'webmock'
+  gem "mock_redis"
+  gem "rspec-rails", "~> 5.1"
+  gem "rspec-sidekiq"
+  gem "shoulda-matchers"
+  gem "simplecov", require: false
+  gem "simplecov-rcov"
+  gem "vcr"
+  gem "webmock"
 end
 
 group :development do
-  gem 'listen', '~> 3.7'
-  gem 'spring'
+  gem "listen", "~> 3.7"
+  gem "spring"
 end
 
-gem 'tzinfo-data'
+gem "tzinfo-data"

--- a/Guardfile
+++ b/Guardfile
@@ -5,7 +5,7 @@ guard "livereload" do
     png: :png,
     gif: :gif,
     jpg: :jpg,
-    jpeg: :jpeg
+    jpeg: :jpeg,
   }
 
   rails_view_exts = %w[erb haml slim]

--- a/Guardfile
+++ b/Guardfile
@@ -1,4 +1,4 @@
-guard 'livereload' do
+guard "livereload" do
   extensions = {
     js: :js,
     html: :html,
@@ -32,8 +32,8 @@ guard 'livereload' do
   watch(%r{config/locales/.+\.yml})
 end
 
-guard :rspec, cmd: 'bundle exec rspec', all_on_start: false do
-  require 'guard/rspec/dsl'
+guard :rspec, cmd: "bundle exec rspec", all_on_start: false do
+  require "guard/rspec/dsl"
   dsl = Guard::RSpec::Dsl.new(self)
 
   rspec = dsl.rspec

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,6 @@
 # Add your own tasks in files placed in lib/tasks ending in .rake,
 # for example lib/tasks/capistrano.rake, and they will automatically be available to Rake.
 
-require_relative 'config/application'
+require_relative "config/application"
 
 Rails.application.load_tasks

--- a/app/controllers/api/V1/submissions_controller.rb
+++ b/app/controllers/api/V1/submissions_controller.rb
@@ -8,10 +8,10 @@ module Api
       rescue_from UnauthorisedApplicationError, with: :unauthorised_application
 
       def create
-        raise InvalidUseCaseError, 'Unauthorised use case' unless authorised_use_case?
+        raise InvalidUseCaseError, "Unauthorised use case" unless authorised_use_case?
 
         submission = Submission.new(filtered_params.merge(use_case: use_case_param,
-                                                          status: 'created',
+                                                          status: "created",
                                                           oauth_application: doorkeeper_token.application))
         submission.save!
         process_submission(submission.id)
@@ -20,7 +20,7 @@ module Api
       end
 
       def result
-        raise UnauthorisedApplicationError, 'Unauthorised application' unless authorised_application?
+        raise UnauthorisedApplicationError, "Unauthorised application" unless authorised_application?
 
         render json: return_body, status: return_status
       rescue ActiveRecord::RecordNotFound
@@ -32,9 +32,9 @@ module Api
       def return_status
         @return_status ||= if completed_but_no_attachment?
                              :internal_server_error
-                           elsif completed_with_attachment? || submission.status.eql?('failed')
+                           elsif completed_with_attachment? || submission.status.eql?("failed")
                              :ok
-                           elsif !submission.status.eql?('completed')
+                           elsif !submission.status.eql?("completed")
                              :accepted
                            end
       end
@@ -43,7 +43,7 @@ module Api
         data_hash = if return_status.eql?(:ok)
                       JSON.parse(attachment.blob.download, symbolize_names: true)
                     elsif completed_but_no_attachment?
-                      { code: 'INCOMPLETE_SUBMISSION', message: 'Process complete but no result available' }
+                      { code: "INCOMPLETE_SUBMISSION", message: "Process complete but no result available" }
                     else
                       { _links: [href: "#{request.base_url}/api/v1/submission/status/#{submission.id}"] }
                     end
@@ -51,11 +51,11 @@ module Api
       end
 
       def unauthorised_use_case
-        render json: { error: 'Unauthorised use case' }.to_json, status: :bad_request
+        render json: { error: "Unauthorised use case" }.to_json, status: :bad_request
       end
 
       def unauthorised_application
-        render json: { error: 'Unauthorised application' }.to_json, status: :bad_request
+        render json: { error: "Unauthorised application" }.to_json, status: :bad_request
       end
 
       def authorised_use_case?
@@ -96,11 +96,11 @@ module Api
       end
 
       def completed_with_attachment?
-        submission.status.eql?('completed') && attachment.present?
+        submission.status.eql?("completed") && attachment.present?
       end
 
       def completed_but_no_attachment?
-        submission.status.eql?('completed') && attachment.nil?
+        submission.status.eql?("completed") && attachment.nil?
       end
 
       def authorised_application?

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,7 +3,7 @@ class ApplicationController < ActionController::API
 
   ERROR_MAPPINGS = {
     ActionController::ParameterMissing => :bad_request,
-    Errors::ContractError => :unprocessable_entity
+    Errors::ContractError => :unprocessable_entity,
   }.freeze
 
   # :nocov:

--- a/app/controllers/smoke_test_controller.rb
+++ b/app/controllers/smoke_test_controller.rb
@@ -16,10 +16,10 @@ private
 
   def run_tests
     {
-      use_case_one: REDIS.get('smoke-test-one'),
-      use_case_two: REDIS.get('smoke-test-two'),
-      use_case_three: REDIS.get('smoke-test-three'),
-      use_case_four: REDIS.get('smoke-test-four')
+      use_case_one: REDIS.get("smoke-test-one"),
+      use_case_two: REDIS.get("smoke-test-two"),
+      use_case_three: REDIS.get("smoke-test-three"),
+      use_case_four: REDIS.get("smoke-test-four")
     }
   end
 

--- a/app/controllers/smoke_test_controller.rb
+++ b/app/controllers/smoke_test_controller.rb
@@ -19,7 +19,7 @@ private
       use_case_one: REDIS.get("smoke-test-one"),
       use_case_two: REDIS.get("smoke-test-two"),
       use_case_three: REDIS.get("smoke-test-three"),
-      use_case_four: REDIS.get("smoke-test-four")
+      use_case_four: REDIS.get("smoke-test-four"),
     }
   end
 

--- a/app/controllers/status_controller.rb
+++ b/app/controllers/status_controller.rb
@@ -6,7 +6,7 @@ class StatusController < ApplicationController
       database: database_alive?,
       redis: redis_alive?,
       sidekiq: sidekiq_alive?,
-      sidekiq_queue: sidekiq_queue_healthy?
+      sidekiq_queue: sidekiq_queue_healthy?,
     }
 
     status = :bad_gateway unless checks.except(:sidekiq_queue).values.all?
@@ -17,7 +17,7 @@ class StatusController < ApplicationController
     render json: {
       "build_date" => Settings.status.build_date,
       "build_tag" => Settings.status.build_tag,
-      "app_branch" => Settings.status.app_branch
+      "app_branch" => Settings.status.app_branch,
     }
   end
 

--- a/app/controllers/status_controller.rb
+++ b/app/controllers/status_controller.rb
@@ -15,9 +15,9 @@ class StatusController < ApplicationController
 
   def ping
     render json: {
-      'build_date' => Settings.status.build_date,
-      'build_tag' => Settings.status.build_tag,
-      'app_branch' => Settings.status.app_branch
+      "build_date" => Settings.status.build_date,
+      "build_tag" => Settings.status.build_tag,
+      "app_branch" => Settings.status.app_branch
     }
   end
 
@@ -30,7 +30,7 @@ private
   end
 
   def redis_alive?
-    REDIS.ping.eql?('PONG')
+    REDIS.ping.eql?("PONG")
   rescue StandardError
     false
   end

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,4 +1,4 @@
 class ApplicationMailer < ActionMailer::Base
-  default from: 'from@example.com'
-  layout 'mailer'
+  default from: "from@example.com"
+  layout "mailer"
 end

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -1,5 +1,5 @@
 class Submission < ApplicationRecord
-  belongs_to :oauth_application, class_name: 'Doorkeeper::Application'
+  belongs_to :oauth_application, class_name: "Doorkeeper::Application"
   has_one_attached :result
 
   NINO_REGEXP = /^[A-CEGHJ-PR-TW-Z]{1}[A-CEGHJ-NPR-TW-Z]{1}[0-9]{6}[A-DFM]{1}$/
@@ -8,7 +8,7 @@ class Submission < ApplicationRecord
 
   before_validation :normalise_nino
 
-  validates :use_case, presence: true, inclusion: { in: USE_CASES, message: 'Invalid use case' }
+  validates :use_case, presence: true, inclusion: { in: USE_CASES, message: "Invalid use case" }
   validates :first_name, presence: true
   validates :last_name, presence: true
   validate :validate_nino
@@ -17,19 +17,19 @@ class Submission < ApplicationRecord
   validates_date :end_date, on_or_before: :today, after: :start_date
 
   def as_json(*)
-    super.except('id', 'status', 'created_at', 'updated_at', 'oauth_application_id')
+    super.except("id", "status", "created_at", "updated_at", "oauth_application_id")
   end
 
   def normalise_nino
     return if nino.blank?
 
-    nino.delete!(' ')
+    nino.delete!(" ")
     nino.upcase!
   end
 
   def validate_nino
     return if NINO_REGEXP.match?(nino)
 
-    errors.add(:nino, 'is not valid')
+    errors.add(:nino, "is not valid")
   end
 end

--- a/app/services/bearer_token.rb
+++ b/app/services/bearer_token.rb
@@ -22,7 +22,7 @@ private
     {
       grant_type: "client_credentials",
       client_secret: "#{totp.now}#{@credentials.hmrc_client_secret}",
-      client_id: @credentials.hmrc_client_id
+      client_id: @credentials.hmrc_client_id,
     }
   end
 

--- a/app/services/bearer_token.rb
+++ b/app/services/bearer_token.rb
@@ -1,7 +1,7 @@
 class BearerToken
   USE_CASES = %w[use_case_one use_case_two use_case_three use_case_four].freeze
   def initialize(for_use_case)
-    raise 'Unsupported UseCase' unless for_use_case.in?(USE_CASES)
+    raise "Unsupported UseCase" unless for_use_case.in?(USE_CASES)
 
     @credentials = Settings.credentials.send(for_use_case)
   end
@@ -13,14 +13,14 @@ class BearerToken
   def call
     response = RestClient.post(url, payload)
     parsed_json = JSON.parse(response.body)
-    parsed_json['access_token']
+    parsed_json["access_token"]
   end
 
 private
 
   def payload
     {
-      grant_type: 'client_credentials',
+      grant_type: "client_credentials",
       client_secret: "#{totp.now}#{@credentials.hmrc_client_secret}",
       client_id: @credentials.hmrc_client_id
     }
@@ -29,7 +29,7 @@ private
   def totp
     ROTP::TOTP.new(@credentials.hmrc_totp_secret,
                    digits: 8,
-                   digest: 'sha512',
+                   digest: "sha512",
                    issuer: @credentials.description)
   end
 

--- a/app/services/concerns/submission_processable.rb
+++ b/app/services/concerns/submission_processable.rb
@@ -4,7 +4,7 @@ module SubmissionProcessable
 private
 
   def process_next_steps(data)
-    return if data.to_s.eql?('INTERNAL_SERVER_ERROR')
+    return if data.to_s.eql?("INTERNAL_SERVER_ERROR")
 
     next_links = extract_next_links(data)
     loop_each next_links if next_links.any?
@@ -26,7 +26,7 @@ private
   end
 
   def extract_data_from(data, parsed_uri)
-    if data.to_s.eql?('INTERNAL_SERVER_ERROR')
+    if data.to_s.eql?("INTERNAL_SERVER_ERROR")
       record_error_data(parsed_uri)
     elsif data_is_valid?(data)
       record_valid_data(data, parsed_uri)
@@ -34,7 +34,7 @@ private
   end
 
   def data_is_valid?(data)
-    (data.is_a?(Array) || data.is_a?(Hash)) && data.except('_links').keys.present?
+    (data.is_a?(Array) || data.is_a?(Hash)) && data.except("_links").keys.present?
   end
 
   def record_valid_data(data, parsed_uri)
@@ -44,23 +44,23 @@ private
   end
 
   def record_error_data(parsed_uri)
-    @result[:data] << { "#{parsed_uri.for_displaying}": 'returned INTERNAL_SERVER_ERROR' }
+    @result[:data] << { "#{parsed_uri.for_displaying}": "returned INTERNAL_SERVER_ERROR" }
   end
 
   def build_data_value(data)
     if data.is_a?(Hash)
-      data[data.except('_links').keys.first]
+      data[data.except("_links").keys.first]
     else
       # :nocov:
       # is this required? (it doesn't seem to be getting called,
       # I am not sure what sort of data structure it would apply to?)
-      data[data.except('_links').keys.first].first
+      data[data.except("_links").keys.first].first
       # :nocov:
     end
   end
 
   def build_data_key(data, parsed_uri)
-    [parsed_uri.for_displaying, data.except('_links').keys.first].join('/').tr('-', '_')
+    [parsed_uri.for_displaying, data.except("_links").keys.first].join("/").tr("-", "_")
   end
 
   def request_endpoint(uri)
@@ -71,15 +71,15 @@ private
     sleep(0.33)
     request_endpoint(uri)
   rescue RestClient::InternalServerError, RestClient::NotFound
-    'INTERNAL_SERVER_ERROR' # TODO: improve this, hard to do currently as only the live service fails
+    "INTERNAL_SERVER_ERROR" # TODO: improve this, hard to do currently as only the live service fails
   end
 
   def request_match_id
-    uri = '/individuals/matching'
+    uri = "/individuals/matching"
     response = RestClient.post("#{host}#{uri}", request_payload, build_headers(uri))
-    JSON.parse(response).dig('_links', 'individual', 'href')
+    JSON.parse(response).dig("_links", "individual", "href")
   rescue RestClient::ExceptionWithResponse => e
-    raise Errors::CitizenDetailsMismatchError, 'User details not matched' if response_code(e, 'MATCHING_FAILED')
+    raise Errors::CitizenDetailsMismatchError, "User details not matched" if response_code(e, "MATCHING_FAILED")
   end
 
   def request_payload
@@ -92,7 +92,7 @@ private
   end
 
   def extract_next_links(data)
-    data['_links'].filter_map { |x| x[1]['href'] unless x[0].eql?('self') }
+    data["_links"].filter_map { |x| x[1]["href"] unless x[0].eql?("self") }
   end
 
   def build_uri(uri)
@@ -108,6 +108,6 @@ private
   end
 
   def response_code(error, text)
-    JSON.parse(error.response.body)['code'].match(/#{text}/)
+    JSON.parse(error.response.body)["code"].match(/#{text}/)
   end
 end

--- a/app/services/concerns/submission_processable.rb
+++ b/app/services/concerns/submission_processable.rb
@@ -87,7 +87,7 @@ private
       firstName: submission.first_name,
       lastName: submission.last_name,
       nino: submission.nino,
-      dateOfBirth: submission.dob
+      dateOfBirth: submission.dob,
     }.to_json
   end
 

--- a/app/services/endpoint/headers.rb
+++ b/app/services/endpoint/headers.rb
@@ -22,7 +22,7 @@ module Endpoint
     def base_headers
       {
         correlationId: @correlation_id.to_s,
-        Authorization: "Bearer #{@token}"
+        Authorization: "Bearer #{@token}",
       }
     end
 

--- a/app/services/endpoint/headers.rb
+++ b/app/services/endpoint/headers.rb
@@ -8,7 +8,7 @@ module Endpoint
 
     def call
       result = base_headers
-      result.merge!(@href.include?('benefits-and-credits') ? v1_headers : v2_headers)
+      result.merge!(@href.include?("benefits-and-credits") ? v1_headers : v2_headers)
       result.merge!(content_type) if @href.match?(%r{individuals/matching$})
       result
     end
@@ -27,15 +27,15 @@ module Endpoint
     end
 
     def content_type
-      { content_type: 'application/json' }
+      { content_type: "application/json" }
     end
 
     def v1_headers
-      { accept: 'application/vnd.hmrc.1.0+json' }
+      { accept: "application/vnd.hmrc.1.0+json" }
     end
 
     def v2_headers
-      { accept: 'application/vnd.hmrc.2.0+json' }
+      { accept: "application/vnd.hmrc.2.0+json" }
     end
   end
 end

--- a/app/services/endpoint/uri.rb
+++ b/app/services/endpoint/uri.rb
@@ -8,17 +8,17 @@ module Endpoint
     def for_calling
       case @href
       when /{&fromDate,toDate}/
-        @href.gsub!('{&fromDate,toDate}', "&fromDate=#{@options[:from_date]}&toDate=#{@options[:to_date]}")
+        @href.gsub!("{&fromDate,toDate}", "&fromDate=#{@options[:from_date]}&toDate=#{@options[:to_date]}")
       when /{&fromTaxYear,toTaxYear}/
-        @href.gsub!('{&fromTaxYear,toTaxYear}', "&fromTaxYear=#{tax_years_from}&toTaxYear=#{tax_years_to}")
+        @href.gsub!("{&fromTaxYear,toTaxYear}", "&fromTaxYear=#{tax_years_from}&toTaxYear=#{tax_years_to}")
       else
         @href
       end
     end
 
     def for_displaying
-      range = @href.include?('matching') ? (1..2) : (2...)
-      Rack::Utils.parse_query(@href).keys[0].gsub(/\?.*/, '').split('/')[range].join('/')
+      range = @href.include?("matching") ? (1..2) : (2...)
+      Rack::Utils.parse_query(@href).keys[0].gsub(/\?.*/, "").split("/")[range].join("/")
     end
 
   private

--- a/app/services/hmrc/sandbox/create_test_data.rb
+++ b/app/services/hmrc/sandbox/create_test_data.rb
@@ -50,7 +50,7 @@ module HMRC
       def path
         {
           employment: "/employment",
-          paye: "/income/paye"
+          paye: "/income/paye",
         }[@type.to_sym]
       end
 
@@ -67,7 +67,7 @@ module HMRC
           apply: "LAA-C1",
           gross_income: "LAA-C2",
           fraud: "LAA-C3",
-          debt: "LAA-C4"
+          debt: "LAA-C4",
         }[@app.to_sym]
       end
 
@@ -75,7 +75,7 @@ module HMRC
         {
           "Content-Type" => "application/json",
           "Accept" => "application/vnd.hmrc.1.0+json",
-          "Authorization" => "Bearer #{@token}"
+          "Authorization" => "Bearer #{@token}",
         }
       end
 

--- a/app/services/hmrc/sandbox/create_test_data.rb
+++ b/app/services/hmrc/sandbox/create_test_data.rb
@@ -7,13 +7,13 @@ module HMRC
       TYPES = %i[employment paye].freeze
 
       def initialize(type, *dates)
-        raise HMRC::Sandbox::ProductionError, 'Cannot run from production' if Settings.environment.eql?('production')
-        raise HMRC::Sandbox::TypeError, 'Type must be :employment or :paye' unless type.in?(TYPES)
+        raise HMRC::Sandbox::ProductionError, "Cannot run from production" if Settings.environment.eql?("production")
+        raise HMRC::Sandbox::TypeError, "Type must be :employment or :paye" unless type.in?(TYPES)
 
         @type = type
         @dates = dates
         build_dates
-        @app = 'apply'
+        @app = "apply"
         @token = UseCase.new(:one).bearer_token
       end
 
@@ -49,8 +49,8 @@ module HMRC
 
       def path
         {
-          employment: '/employment',
-          paye: '/income/paye'
+          employment: "/employment",
+          paye: "/income/paye"
         }[@type.to_sym]
       end
 
@@ -64,27 +64,27 @@ module HMRC
 
       def use_case
         {
-          apply: 'LAA-C1',
-          gross_income: 'LAA-C2',
-          fraud: 'LAA-C3',
-          debt: 'LAA-C4'
+          apply: "LAA-C1",
+          gross_income: "LAA-C2",
+          fraud: "LAA-C3",
+          debt: "LAA-C4"
         }[@app.to_sym]
       end
 
       def headers
         {
-          'Content-Type' => 'application/json',
-          'Accept' => 'application/vnd.hmrc.1.0+json',
-          'Authorization' => "Bearer #{@token}"
+          "Content-Type" => "application/json",
+          "Accept" => "application/vnd.hmrc.1.0+json",
+          "Authorization" => "Bearer #{@token}"
         }
       end
 
       def paye_data
-        JSON.parse(File.read('spec/fixtures/test_data/paye.json'))
+        JSON.parse(File.read("spec/fixtures/test_data/paye.json"))
       end
 
       def employment_data
-        JSON.parse(File.read('spec/fixtures/test_data/employment.json'))
+        JSON.parse(File.read("spec/fixtures/test_data/employment.json"))
       end
     end
   end

--- a/app/services/queue_name_service.rb
+++ b/app/services/queue_name_service.rb
@@ -4,15 +4,15 @@ class QueueNameService
   end
 
   def call
-    if Settings.sentry.environment == 'uat'
+    if Settings.sentry.environment == "uat"
       "#{uat_queue_name}-submissions"
     else
-      'submissions'
+      "submissions"
     end
   end
 
   def uat_queue_name
     branch_name = Settings.status.app_branch
-    branch_name.tr(' _/[]().', '-')
+    branch_name.tr(" _/[]().", "-")
   end
 end

--- a/app/services/smoke_test.rb
+++ b/app/services/smoke_test.rb
@@ -8,8 +8,8 @@ class SmokeTest
   end
 
   def call
-    actual = JSON.parse(actual_response)['data']
-    expected = JSON.parse(expected_response)['data']
+    actual = JSON.parse(actual_response)["data"]
+    expected = JSON.parse(expected_response)["data"]
     diff = (actual - expected) + (expected - actual)
     result = diff.empty?
     REDIS.setex("smoke-test-#{@use_case}", 3600, result)

--- a/app/services/submission_service.rb
+++ b/app/services/submission_service.rb
@@ -19,10 +19,10 @@ class SubmissionService
     data = request_and_extract_data(request_match_id)
     process_next_steps(data)
   rescue Errors::CitizenDetailsMismatchError
-    @result[:data] << { error: 'submitted client details could not be found in HMRC service' }
+    @result[:data] << { error: "submitted client details could not be found in HMRC service" }
     raise
   ensure
     @submission.result.attach(io: StringIO.new(@result.to_json), filename: "#{@submission.id}.json",
-                              content_type: 'application/json', key: "submission/result/#{@submission.id}")
+                              content_type: "application/json", key: "submission/result/#{@submission.id}")
   end
 end

--- a/app/services/test_submission.rb
+++ b/app/services/test_submission.rb
@@ -23,7 +23,7 @@ class TestSubmission
 
   def self.call_with(submission)
     use_case = submission.use_case.to_sym
-    values = submission.as_json.except('use_case').symbolize_keys
+    values = submission.as_json.except("use_case").symbolize_keys
     new(use_case, **values).call(correlation_id: submission.id)
   end
 

--- a/app/services/test_submission.rb
+++ b/app/services/test_submission.rb
@@ -13,7 +13,7 @@ class TestSubmission
       nino: args[:nino],
       dob: args[:dob],
       start_date: args[:start_date],
-      end_date: args[:end_date]
+      end_date: args[:end_date],
     }.to_json, object_class: Submission)
   end
 

--- a/app/workers/submission_process_worker.rb
+++ b/app/workers/submission_process_worker.rb
@@ -12,14 +12,14 @@ class SubmissionProcessWorker
 
   def perform(submission_id)
     submission = Submission.find(submission_id)
-    submission.update!(status: 'processing')
+    submission.update!(status: "processing")
 
     SubmissionService.call(submission)
-    submission.update!(status: 'completed')
+    submission.update!(status: "completed")
   rescue Errors::CitizenDetailsMismatchError
-    submission.update!(status: 'failed')
+    submission.update!(status: "failed")
   rescue StandardError
-    submission.update!(status: 'failed') && raise if @retry_count >= MAX_RETRIES
+    submission.update!(status: "failed") && raise if @retry_count >= MAX_RETRIES
 
     raise Errors::SentryIgnoresThisSidekiqFailError, retry_error_message(submission_id)
   end

--- a/config/application.rb
+++ b/config/application.rb
@@ -1,17 +1,17 @@
-require_relative 'boot'
+require_relative "boot"
 
-require 'rails'
+require "rails"
 # Pick the frameworks you want:
-require 'active_model/railtie'
-require 'active_job/railtie'
-require 'active_record/railtie'
-require 'active_storage/engine'
-require 'action_controller/railtie'
-require 'action_mailer/railtie'
-require 'action_mailbox/engine'
-require 'action_text/engine'
-require 'action_view/railtie'
-require 'action_cable/engine'
+require "active_model/railtie"
+require "active_job/railtie"
+require "active_record/railtie"
+require "active_storage/engine"
+require "action_controller/railtie"
+require "action_mailer/railtie"
+require "action_mailbox/engine"
+require "action_text/engine"
+require "action_view/railtie"
+require "action_cable/engine"
 # require "sprockets/railtie"
 # require "rails/test_unit/railtie"
 

--- a/config/boot.rb
+++ b/config/boot.rb
@@ -1,4 +1,4 @@
-ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../Gemfile', __dir__)
+ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../Gemfile", __dir__)
 
-require 'bundler/setup' # Set up gems listed in the Gemfile.
-require 'bootsnap/setup' # Speed up boot time by caching expensive operations.
+require "bundler/setup" # Set up gems listed in the Gemfile.
+require "bootsnap/setup" # Speed up boot time by caching expensive operations.

--- a/config/environment.rb
+++ b/config/environment.rb
@@ -1,5 +1,5 @@
 # Load the Rails application.
-require_relative 'application'
+require_relative "application"
 
 # Initialize the Rails application.
 Rails.application.initialize!

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -1,4 +1,4 @@
-require 'active_support/core_ext/integer/time'
+require "active_support/core_ext/integer/time"
 
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
@@ -16,10 +16,10 @@ Rails.application.configure do
 
   # Enable/disable caching. By default caching is disabled.
   # Run rails dev:cache to toggle caching.
-  if Rails.root.join('tmp/caching-dev.txt').exist?
+  if Rails.root.join("tmp/caching-dev.txt").exist?
     config.cache_store = :memory_store
     config.public_file_server.headers = {
-      'Cache-Control' => "public, max-age=#{2.days.to_i}"
+      "Cache-Control" => "public, max-age=#{2.days.to_i}"
     }
   else
     config.action_controller.perform_caching = false

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -19,7 +19,7 @@ Rails.application.configure do
   if Rails.root.join("tmp/caching-dev.txt").exist?
     config.cache_store = :memory_store
     config.public_file_server.headers = {
-      "Cache-Control" => "public, max-age=#{2.days.to_i}"
+      "Cache-Control" => "public, max-age=#{2.days.to_i}",
     }
   else
     config.action_controller.perform_caching = false

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -1,4 +1,4 @@
-require 'active_support/core_ext/integer/time'
+require "active_support/core_ext/integer/time"
 
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
@@ -21,7 +21,7 @@ Rails.application.configure do
 
   # Disable serving static files from the `/public` folder by default since
   # Apache or NGINX already handles this.
-  config.public_file_server.enabled = ENV['RAILS_SERVE_STATIC_FILES'].present?
+  config.public_file_server.enabled = ENV["RAILS_SERVE_STATIC_FILES"].present?
 
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.
   # config.asset_host = 'http://assets.example.com'
@@ -81,7 +81,7 @@ Rails.application.configure do
   # require "syslog/logger"
   # config.logger = ActiveSupport::TaggedLogging.new(Syslog::Logger.new 'app-name')
 
-  if ENV['RAILS_LOG_TO_STDOUT'].present?
+  if ENV["RAILS_LOG_TO_STDOUT"].present?
     logger           = ActiveSupport::Logger.new($stdout)
     logger.formatter = config.log_formatter
     config.logger    = ActiveSupport::TaggedLogging.new(logger)

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -19,7 +19,7 @@ Rails.application.configure do
   # Configure public file server for tests with Cache-Control for performance.
   config.public_file_server.enabled = true
   config.public_file_server.headers = {
-    "Cache-Control" => "public, max-age=#{1.hour.to_i}"
+    "Cache-Control" => "public, max-age=#{1.hour.to_i}",
   }
 
   # Show full error reports and disable caching.

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -1,4 +1,4 @@
-require 'active_support/core_ext/integer/time'
+require "active_support/core_ext/integer/time"
 
 # The test environment is used exclusively to run your application's
 # test suite. You never need to work with it otherwise. Remember that
@@ -19,7 +19,7 @@ Rails.application.configure do
   # Configure public file server for tests with Cache-Control for performance.
   config.public_file_server.enabled = true
   config.public_file_server.headers = {
-    'Cache-Control' => "public, max-age=#{1.hour.to_i}"
+    "Cache-Control" => "public, max-age=#{1.hour.to_i}"
   }
 
   # Show full error reports and disable caching.

--- a/config/initializers/backtrace_silencers.rb
+++ b/config/initializers/backtrace_silencers.rb
@@ -5,4 +5,4 @@
 
 # You can also remove all the silencers if you're trying to debug a problem that might stem from framework code
 # by setting BACKTRACE=1 before calling your invocation, like "BACKTRACE=1 ./bin/rails runner 'MyClass.perform'".
-Rails.backtrace_cleaner.remove_silencers! if ENV['BACKTRACE']
+Rails.backtrace_cleaner.remove_silencers! if ENV["BACKTRACE"]

--- a/config/initializers/config.rb
+++ b/config/initializers/config.rb
@@ -1,9 +1,9 @@
 Config.setup do |config|
   # Name of the constant exposing loaded settings
-  config.const_name = 'Settings'
+  config.const_name = "Settings"
   config.use_env = true
-  config.env_prefix = 'SETTINGS'
-  config.env_separator = '__'
+  config.env_prefix = "SETTINGS"
+  config.env_separator = "__"
   config.env_converter = :downcase
 
   # Ability to remove elements of the array set in earlier loaded settings file. For example value: '--'.

--- a/config/initializers/doorkeeper.rb
+++ b/config/initializers/doorkeeper.rb
@@ -100,7 +100,7 @@ Doorkeeper.configure do
   # Access token expiration time (default: 2 hours).
   # If you want to disable expiration, set this to `nil`.
   #
-  access_token_expires_in 5.minutes if ENV.fetch('HOST_ENV', nil).eql?('dev')
+  access_token_expires_in 5.minutes if ENV.fetch("HOST_ENV", nil).eql?("dev")
 
   # Assign custom TTL for access tokens. Will be used instead of access_token_expires_in
   # option if defined. In case the block returns `nil` value Doorkeeper fallbacks to

--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -10,7 +10,7 @@ filter_sensitive_info = lambda do |_key, value|
 
   next if /^[0-9a-fA-F]{8}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{12}$/i.match?(value.to_s)
 
-  value.to_s.replace '[FILTERED]'
+  value.to_s.replace "[FILTERED]"
 end
 
 Rails.application.config.filter_parameters += [:password, filter_sensitive_info]

--- a/config/initializers/inflections.rb
+++ b/config/initializers/inflections.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 ActiveSupport::Inflector.inflections(:en) do |inflect|
-  inflect.acronym 'HMRC'
+  inflect.acronym "HMRC"
 end

--- a/config/initializers/redis.rb
+++ b/config/initializers/redis.rb
@@ -1,1 +1,1 @@
-REDIS = Redis::Namespace.new('lhisa_uat', redis: Redis.new) unless Rails.env.test?
+REDIS = Redis::Namespace.new("lhisa_uat", redis: Redis.new) unless Rails.env.test?

--- a/config/initializers/rswag_api.rb
+++ b/config/initializers/rswag_api.rb
@@ -3,7 +3,7 @@ Rswag::Api.configure do |c|
   # This is used by the Swagger middleware to serve requests for API descriptions
   # NOTE: If you're using rswag-specs to generate Swagger, you'll need to ensure
   # that it's configured to generate files in the same folder
-  c.swagger_root = Rails.root.join('swagger')
+  c.swagger_root = Rails.root.join("swagger")
 
   # Inject a lamda function to alter the returned Swagger prior to serialization
   # The function will have access to the rack env for the current request

--- a/config/initializers/rswag_ui.rb
+++ b/config/initializers/rswag_ui.rb
@@ -5,7 +5,7 @@ Rswag::Ui.configure do |c|
   # NOTE: If you're using rspec-api to expose Swagger files (under swagger_root) as JSON or YAML endpoints,
   # then the list below should correspond to the relative paths for those endpoints
 
-  c.swagger_endpoint '/api-docs/v1/swagger.yaml', 'API V1 Docs'
+  c.swagger_endpoint "/api-docs/v1/swagger.yaml", "API V1 Docs"
 
   # Add Basic Auth in case your API is private
   # c.basic_auth_enabled = true

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -1,5 +1,5 @@
 Sentry.init do |config|
-  config.dsn = Settings.sentry.dsn unless Settings.sentry.environment.eql?('test')
+  config.dsn = Settings.sentry.dsn unless Settings.sentry.environment.eql?("test")
   config.breadcrumbs_logger = %i[active_support_logger http_logger]
   config.environment = Settings.sentry.environment
   config.excluded_exceptions += %w[

--- a/config/initializers/sidekiq_middleware.rb
+++ b/config/initializers/sidekiq_middleware.rb
@@ -1,6 +1,6 @@
 class SidekiqMiddleware
   def call(worker, job, _queue)
-    worker.retry_count = job['retry_count'].nil? ? 0 : job['retry_count'] + 1 if worker.respond_to?(:retry_count=)
+    worker.retry_count = job["retry_count"].nil? ? 0 : job["retry_count"] + 1 if worker.respond_to?(:retry_count=)
     yield
   end
 end

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -4,25 +4,25 @@
 # the maximum value specified for Puma. Default is set to 5 threads for minimum
 # and maximum; this matches the default thread size of Active Record.
 #
-max_threads_count = ENV.fetch('RAILS_MAX_THREADS', 5)
-min_threads_count = ENV.fetch('RAILS_MIN_THREADS') { max_threads_count }
+max_threads_count = ENV.fetch("RAILS_MAX_THREADS", 5)
+min_threads_count = ENV.fetch("RAILS_MIN_THREADS") { max_threads_count }
 threads min_threads_count, max_threads_count
 
 # Specifies the `worker_timeout` threshold that Puma will use to wait before
 # terminating a worker in development environments.
 #
-worker_timeout 3600 if ENV.fetch('RAILS_ENV', 'development') == 'development'
+worker_timeout 3600 if ENV.fetch("RAILS_ENV", "development") == "development"
 
 # Specifies the `port` that Puma will listen on to receive requests; default is 3000.
 #
-port ENV.fetch('PORT', 3000)
+port ENV.fetch("PORT", 3000)
 
 # Specifies the `environment` that Puma will run in.
 #
-environment ENV.fetch('RAILS_ENV', 'development')
+environment ENV.fetch("RAILS_ENV", "development")
 
 # Specifies the `pidfile` that Puma will use.
-pidfile ENV.fetch('PIDFILE', 'tmp/pids/server.pid')
+pidfile ENV.fetch("PIDFILE", "tmp/pids/server.pid")
 
 # Specifies the number of `workers` to boot in clustered mode.
 # Workers are forked web server processes. If using threads and workers together

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,4 @@
-require 'sidekiq/web'
+require "sidekiq/web"
 
 # Configure Sidekiq-specific session middleware
 Sidekiq::Web.use ActionDispatch::Cookies
@@ -6,9 +6,9 @@ Sidekiq::Web.use Rails.application.config.session_store, Rails.application.confi
 
 Rails.application.routes.draw do
   use_doorkeeper
-  mount Rswag::Ui::Engine => '/api-docs'
-  mount Rswag::Api::Engine => '/api-docs'
-  mount Sidekiq::Web => '/sidekiq'
+  mount Rswag::Ui::Engine => "/api-docs"
+  mount Rswag::Api::Engine => "/api-docs"
+  mount Sidekiq::Web => "/sidekiq"
 
   Sidekiq::Web.use Rack::Auth::Basic do |username, password|
     # Protect against timing attacks:
@@ -19,25 +19,25 @@ Rails.application.routes.draw do
     secure_compare(username, Settings.sidekiq.username) & secure_compare(password, Settings.sidekiq.web_ui_password)
   end
 
-  root to: 'main#show'
-  get 'main', to: 'main#show', format: :json
-  get 'ping', to: 'status#ping', format: :json
-  get 'health_check', to: 'status#health_check', format: :json
-  get 'status', to: 'status#ping', format: :json
-  unless Settings.environment.eql?('live')
-    get 'smoke-test/:use_case', to: 'smoke_test#call', as: 'smoke-test-use-case', format: :json
-    get 'smoke-test', to: 'smoke_test#health_check', format: :json
+  root to: "main#show"
+  get "main", to: "main#show", format: :json
+  get "ping", to: "status#ping", format: :json
+  get "health_check", to: "status#health_check", format: :json
+  get "status", to: "status#ping", format: :json
+  unless Settings.environment.eql?("live")
+    get "smoke-test/:use_case", to: "smoke_test#call", as: "smoke-test-use-case", format: :json
+    get "smoke-test", to: "smoke_test#health_check", format: :json
   end
 
   namespace :api do
     namespace :v1 do
-      post 'submission/create/:use_case', to: 'submissions#create', format: :json
-      get 'submission/status/:id', to: 'submissions#status', as: 'submission-status-id', format: :json
-      get 'submission/result/:id', to: 'submissions#result', as: 'submission-result-id', format: :json
-      get 'use_case/one', to: 'use_case#one', format: :json
-      get 'use_case/two', to: 'use_case#two', format: :json
-      get 'use_case/three', to: 'use_case#three', format: :json
-      get 'use_case/four', to: 'use_case#four', format: :json
+      post "submission/create/:use_case", to: "submissions#create", format: :json
+      get "submission/status/:id", to: "submissions#status", as: "submission-status-id", format: :json
+      get "submission/result/:id", to: "submissions#result", as: "submission-result-id", format: :json
+      get "use_case/one", to: "use_case#one", format: :json
+      get "use_case/two", to: "use_case#two", format: :json
+      get "use_case/three", to: "use_case#three", format: :json
+      get "use_case/four", to: "use_case#four", format: :json
     end
   end
 end

--- a/config/spring.rb
+++ b/config/spring.rb
@@ -1,6 +1,6 @@
 Spring.watch(
-  '.ruby-version',
-  '.rbenv-vars',
-  'tmp/restart.txt',
-  'tmp/caching-dev.txt',
+  ".ruby-version",
+  ".rbenv-vars",
+  "tmp/restart.txt",
+  "tmp/caching-dev.txt",
 )

--- a/db/migrate/20210826104043_enable_uuid_extension.rb
+++ b/db/migrate/20210826104043_enable_uuid_extension.rb
@@ -1,5 +1,5 @@
 class EnableUuidExtension < ActiveRecord::Migration[6.1]
   def change
-    enable_extension 'pgcrypto'
+    enable_extension "pgcrypto"
   end
 end

--- a/db/migrate/20210901112748_create_doorkeeper_tables.rb
+++ b/db/migrate/20210901112748_create_doorkeeper_tables.rb
@@ -12,7 +12,7 @@ class CreateDoorkeeperTables < ActiveRecord::Migration[6.1]
       # like Client Credentials flow or Resource Owner Password.
       t.text    :redirect_uri
       t.boolean :confidential, null: false, default: true
-      t.string  :scopes,       null: false, default: ''
+      t.string  :scopes,       null: false, default: ""
       t.timestamps             null: false
     end
 
@@ -24,7 +24,7 @@ class CreateDoorkeeperTables < ActiveRecord::Migration[6.1]
       t.string   :token,             null: false
       t.integer  :expires_in,        null: false
       t.text     :redirect_uri,      null: false
-      t.string   :scopes,            null: false, default: ''
+      t.string   :scopes,            null: false, default: ""
       t.datetime :created_at,        null: false
       t.datetime :revoked_at
     end
@@ -70,7 +70,7 @@ class CreateDoorkeeperTables < ActiveRecord::Migration[6.1]
       #
       # Comment out this line if you want refresh tokens to be instantly
       # revoked after use.
-      t.string   :previous_refresh_token, null: false, default: ''
+      t.string   :previous_refresh_token, null: false, default: ""
     end
 
     add_index :oauth_access_tokens, :token, unique: true

--- a/db/populators/oauth_account_populator.rb
+++ b/db/populators/oauth_account_populator.rb
@@ -1,12 +1,12 @@
 class OauthAccountPopulator
-  DATA_FILE = Rails.root.join('db/seed_data/test_oauth_accounts.yml').freeze
+  DATA_FILE = Rails.root.join("db/seed_data/test_oauth_accounts.yml").freeze
 
   def self.call
     new.call
   end
 
   def call
-    seed_data.each { |seed_row| populate(seed_row) }.freeze unless Settings.environment.eql?('live')
+    seed_data.each { |seed_row| populate(seed_row) }.freeze unless Settings.environment.eql?("live")
   end
 
 private

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -9,10 +9,10 @@
 #   Character.create(name: 'Luke', movie: movies.first)
 
 Rails.logger.debug "Seeding the database...\n"
-Dir[Rails.root.join('db/populators/*.rb')].each do |seed_file|
+Dir[Rails.root.join("db/populators/*.rb")].each do |seed_file|
   load seed_file
 end
 
 OauthAccountPopulator.call
 
-Rails.logger.debug 'Seeding complete.'
+Rails.logger.debug "Seeding complete."

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -1,4 +1,4 @@
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe ApplicationController, type: :controller do
   include AuthorisedRequestHelper
@@ -9,5 +9,5 @@ RSpec.describe ApplicationController, type: :controller do
     end
   end
 
-  it_behaves_like 'an unauthorised request'
+  it_behaves_like "an unauthorised request"
 end

--- a/spec/factories/submission_factory.rb
+++ b/spec/factories/submission_factory.rb
@@ -26,9 +26,9 @@ FactoryBot.define do
 
   trait :with_attachment do
     after :create do |submission|
-      submission.result.attach(io: File.open('spec/fixtures/test_result.json'),
+      submission.result.attach(io: File.open("spec/fixtures/test_result.json"),
                                filename: "#{submission.id}.json",
-                               content_type: 'application/json',
+                               content_type: "application/json",
                                key: "submission/result/#{submission.id}")
       submission.reload
     end
@@ -36,9 +36,9 @@ FactoryBot.define do
   trait :failed_with_attachment do
     status { :failed }
     after :create do |submission|
-      submission.result.attach(io: File.open('spec/fixtures/test_result_failed.json'),
+      submission.result.attach(io: File.open("spec/fixtures/test_result_failed.json"),
                                filename: "#{submission.id}.json",
-                               content_type: 'application/json',
+                               content_type: "application/json",
                                key: "submission/result/#{submission.id}")
       submission.reload
     end

--- a/spec/models/submission_spec.rb
+++ b/spec/models/submission_spec.rb
@@ -1,19 +1,19 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe Submission, type: :model do
   subject(:submission) { described_class.create(params) }
 
   let(:params) do
     {
-      use_case: 'one',
-      first_name: 'Langley',
-      last_name: 'Yorke',
-      nino: 'MN212451D',
-      dob: '1992-07-22',
-      start_date: '2020-08-01',
-      end_date: '2020-10-01'
+      use_case: "one",
+      first_name: "Langley",
+      last_name: "Yorke",
+      nino: "MN212451D",
+      dob: "1992-07-22",
+      start_date: "2020-08-01",
+      end_date: "2020-10-01"
     }
   end
 
@@ -21,209 +21,209 @@ RSpec.describe Submission, type: :model do
     expect(submission).to validate_inclusion_of(:use_case).in_array(%w[one two three four]).with_message(/Invalid use case/)
   }
 
-  describe '.as_json' do
+  describe ".as_json" do
     subject(:as_json) { submission.as_json }
 
-    it 'returns the expected values' do
+    it "returns the expected values" do
       expect(as_json.keys).to match_array %w[use_case first_name last_name nino dob start_date end_date]
     end
 
-    it 'does not include standard model values' do
+    it "does not include standard model values" do
       expect(as_json.keys).not_to include %w[id status created_at updated_at]
     end
   end
 
-  describe '#save' do
-    context 'with first name missing' do
+  describe "#save" do
+    context "with first name missing" do
       before { params.delete(:first_name) }
 
-      it 'does not persist model' do
+      it "does not persist model" do
         expect { submission.save }.not_to(change(described_class, :count))
       end
 
-      it 'raises an error' do
+      it "raises an error" do
         expect { submission.save! }.to raise_error(ActiveRecord::RecordInvalid)
         expect(submission.errors.full_messages).to include("First name can't be blank")
       end
     end
 
-    context 'with last name missing' do
+    context "with last name missing" do
       before { params.delete(:last_name) }
 
-      it 'does not persist model' do
+      it "does not persist model" do
         expect { submission.save }.not_to(change(described_class, :count))
       end
 
-      it 'raises an error' do
+      it "raises an error" do
         expect { submission.save! }.to raise_error(ActiveRecord::RecordInvalid)
         expect(submission.errors.full_messages).to include("Last name can't be blank")
       end
     end
 
-    context 'with nino errors' do
-      context 'with nino missing' do
+    context "with nino errors" do
+      context "with nino missing" do
         before { params.delete(:nino) }
 
-        it 'does not persist model' do
+        it "does not persist model" do
           expect { submission.save }.not_to(change(described_class, :count))
         end
 
-        it 'raises an error' do
+        it "raises an error" do
           expect { submission.save! }.to raise_error(ActiveRecord::RecordInvalid)
-          expect(submission.errors.full_messages).to include('Nino is not valid')
+          expect(submission.errors.full_messages).to include("Nino is not valid")
         end
       end
 
-      context 'with an invalid nino' do
-        before { params[:nino] = 'invalid_nino' }
+      context "with an invalid nino" do
+        before { params[:nino] = "invalid_nino" }
 
-        it 'does not persist model' do
+        it "does not persist model" do
           expect { submission.save }.not_to(change(described_class, :count))
         end
 
-        it 'raises an error' do
+        it "raises an error" do
           expect { submission.save! }.to raise_error(ActiveRecord::RecordInvalid)
-          expect(submission.errors.full_messages).to include('Nino is not valid')
+          expect(submission.errors.full_messages).to include("Nino is not valid")
         end
       end
     end
 
-    context 'with dob errors' do
-      context 'with dob missing' do
+    context "with dob errors" do
+      context "with dob missing" do
         before { params.delete(:dob) }
 
-        it 'does not persist model' do
+        it "does not persist model" do
           expect { submission.save }.not_to(change(described_class, :count))
         end
 
-        it 'raises an error' do
+        it "raises an error" do
           expect { submission.save! }.to raise_error(ActiveRecord::RecordInvalid)
-          expect(submission.errors.full_messages).to include('Dob is not a valid date')
+          expect(submission.errors.full_messages).to include("Dob is not a valid date")
         end
       end
 
-      context 'with a badly formatted dob' do
-        before { params[:dob] = 'date' }
+      context "with a badly formatted dob" do
+        before { params[:dob] = "date" }
 
-        it 'does not persist model' do
+        it "does not persist model" do
           expect { submission.save }.not_to(change(described_class, :count))
         end
 
-        it 'raises an error' do
+        it "raises an error" do
           expect { submission.save! }.to raise_error(ActiveRecord::RecordInvalid)
-          expect(submission.errors.full_messages).to include('Dob is not a valid date')
+          expect(submission.errors.full_messages).to include("Dob is not a valid date")
         end
       end
 
-      context 'with a dob in the future' do
+      context "with a dob in the future" do
         before { params[:dob] = Time.zone.today + 1 }
 
-        it 'does not persist model' do
+        it "does not persist model" do
           expect { submission.save }.not_to(change(described_class, :count))
         end
 
-        it 'raises an error' do
+        it "raises an error" do
           expect { submission.save! }.to raise_error(ActiveRecord::RecordInvalid)
-          expect(submission.errors.full_messages).to include('Dob is not a valid date')
+          expect(submission.errors.full_messages).to include("Dob is not a valid date")
         end
       end
     end
 
-    context 'with start_date errors' do
-      context 'with start_date missing' do
+    context "with start_date errors" do
+      context "with start_date missing" do
         before { params.delete(:start_date) }
 
-        it 'does not persist model' do
+        it "does not persist model" do
           expect { submission.save }.not_to(change(described_class, :count))
         end
 
-        it 'raises an error' do
+        it "raises an error" do
           expect { submission.save! }.to raise_error(ActiveRecord::RecordInvalid)
-          expect(submission.errors.full_messages).to include('Start date is not a valid date')
+          expect(submission.errors.full_messages).to include("Start date is not a valid date")
         end
       end
 
-      context 'with a badly formatted start_date' do
-        before { params[:start_date] = 'date' }
+      context "with a badly formatted start_date" do
+        before { params[:start_date] = "date" }
 
-        it 'does not persist model' do
+        it "does not persist model" do
           expect { submission.save }.not_to(change(described_class, :count))
         end
 
-        it 'raises an error' do
+        it "raises an error" do
           expect { submission.save! }.to raise_error(ActiveRecord::RecordInvalid)
-          expect(submission.errors.full_messages).to include('Start date is not a valid date')
+          expect(submission.errors.full_messages).to include("Start date is not a valid date")
         end
       end
 
-      context 'with a start_date in the future' do
+      context "with a start_date in the future" do
         before { params[:start_date] = Time.zone.today + 1 }
 
-        it 'does not persist model' do
+        it "does not persist model" do
           expect { submission.save }.not_to(change(described_class, :count))
         end
 
-        it 'raises an error' do
+        it "raises an error" do
           expect { submission.save! }.to raise_error(ActiveRecord::RecordInvalid)
-          expect(submission.errors.full_messages).to include('Start date is not a valid date')
+          expect(submission.errors.full_messages).to include("Start date is not a valid date")
         end
       end
     end
 
-    context 'with end_date errors' do
-      context 'with end_date missing' do
+    context "with end_date errors" do
+      context "with end_date missing" do
         before { params.delete(:end_date) }
 
-        it 'does not persist model' do
+        it "does not persist model" do
           expect { submission.save }.not_to(change(described_class, :count))
         end
 
-        it 'raises an error' do
+        it "raises an error" do
           expect { submission.save! }.to raise_error(ActiveRecord::RecordInvalid)
-          expect(submission.errors.full_messages).to include('End date is not a valid date')
+          expect(submission.errors.full_messages).to include("End date is not a valid date")
         end
       end
 
-      context 'with a badly formatted end_date' do
-        before { params[:end_date] = 'date' }
+      context "with a badly formatted end_date" do
+        before { params[:end_date] = "date" }
 
-        it 'does not persist model' do
+        it "does not persist model" do
           expect { submission.save }.not_to(change(described_class, :count))
         end
 
-        it 'raises an error' do
+        it "raises an error" do
           expect { submission.save! }.to raise_error(ActiveRecord::RecordInvalid)
-          expect(submission.errors.full_messages).to include('End date is not a valid date')
+          expect(submission.errors.full_messages).to include("End date is not a valid date")
         end
       end
 
-      context 'with an end_date in the future' do
+      context "with an end_date in the future" do
         before { params[:end_date] = Time.zone.today + 1 }
 
-        it 'does not persist model' do
+        it "does not persist model" do
           expect { submission.save }.not_to(change(described_class, :count))
         end
 
-        it 'raises an error' do
+        it "raises an error" do
           expect { submission.save! }.to raise_error(ActiveRecord::RecordInvalid)
-          expect(submission.errors.full_messages).to include('End date is not a valid date')
+          expect(submission.errors.full_messages).to include("End date is not a valid date")
         end
       end
 
-      context 'with an end_date before the start_date' do
+      context "with an end_date before the start_date" do
         before do
           params[:start_date] = Time.zone.today - 9
           params[:end_date] = Time.zone.today - 10
         end
 
-        it 'does not persist model' do
+        it "does not persist model" do
           expect { submission.save }.not_to(change(described_class, :count))
         end
 
-        it 'raises an error' do
+        it "raises an error" do
           expect { submission.save! }.to raise_error(ActiveRecord::RecordInvalid)
-          expect(submission.errors.full_messages).to include('Start date is not a valid date',
-                                                             'End date is not a valid date')
+          expect(submission.errors.full_messages).to include("Start date is not a valid date",
+                                                             "End date is not a valid date")
         end
       end
     end

--- a/spec/models/submission_spec.rb
+++ b/spec/models/submission_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Submission, type: :model do
       nino: "MN212451D",
       dob: "1992-07-22",
       start_date: "2020-08-01",
-      end_date: "2020-10-01"
+      end_date: "2020-10-01",
     }
   end
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,10 +1,10 @@
 # This file is copied to spec/ when you run 'rails generate rspec:install'
-require 'spec_helper'
-ENV['RAILS_ENV'] ||= 'test'
-require File.expand_path('../config/environment', __dir__)
+require "spec_helper"
+ENV["RAILS_ENV"] ||= "test"
+require File.expand_path("../config/environment", __dir__)
 # Prevent database truncation if the environment is production
-abort('The Rails environment is running in production mode!') if Rails.env.production?
-require 'rspec/rails'
+abort("The Rails environment is running in production mode!") if Rails.env.production?
+require "rspec/rails"
 # Add additional requires below this line. Rails is not loaded until this point!
 
 # Requires supporting ruby files with custom matchers and macros, etc, in
@@ -22,7 +22,7 @@ require 'rspec/rails'
 #
 # Dir[Rails.root.join('spec', 'support', '**', '*.rb')].sort.each { |f| require f }
 
-Dir[Rails.root.join('spec/support/**/*.rb')].each { |f| require f }
+Dir[Rails.root.join("spec/support/**/*.rb")].each { |f| require f }
 
 # Checks for pending migrations and applies them before tests are run.
 # If you are not using ActiveRecord, you can remove these lines.

--- a/spec/requests/api/v1/submissions_swagger_spec.rb
+++ b/spec/requests/api/v1/submissions_swagger_spec.rb
@@ -19,8 +19,8 @@ RSpec.describe "GET submission", type: :request, swagger_doc: "v1/swagger.yaml" 
           nino: "MN212451D",
           dob: "1992-07-22",
           start_date: "2020-08-01",
-          end_date: "2020-10-01"
-        }
+          end_date: "2020-10-01",
+        },
       }
     end
 
@@ -50,18 +50,18 @@ RSpec.describe "GET submission", type: :request, swagger_doc: "v1/swagger.yaml" 
                           nino: { type: String, example: "MN212451D" },
                           dob: { type: Date, example: "1992-07-22" },
                           start_date: { type: Date, example: "2020-08-01" },
-                          end_date: { type: Date, example: "2020-10-01" }
-                        }
-                      }
-                    }
+                          end_date: { type: Date, example: "2020-10-01" },
+                        },
+                      },
+                    },
                   }
         response(202, "Accepted") do
           description "Create a submission record and start the HMRC process asynchronously"
           after do |example|
             example.metadata[:response][:content] = {
               "application/json" => {
-                example: JSON.parse(response.body, symbolize_names: true)
-              }
+                example: JSON.parse(response.body, symbolize_names: true),
+              },
             }
           end
 
@@ -100,8 +100,8 @@ RSpec.describe "GET submission", type: :request, swagger_doc: "v1/swagger.yaml" 
                   nino: "abc123",
                   dob: "1234",
                   start_date: nil,
-                  end_date: nil
-                }
+                  end_date: nil,
+                },
               }
             end
             run_test! do |response|
@@ -153,7 +153,7 @@ RSpec.describe "GET submission", type: :request, swagger_doc: "v1/swagger.yaml" 
               data: [
                 { correlation_id: "test-guid", use_case: "use_case_two" },
                 { test_key: "test value" },
-              ]
+              ],
             }
           end
           run_test! do |response|
@@ -171,7 +171,7 @@ RSpec.describe "GET submission", type: :request, swagger_doc: "v1/swagger.yaml" 
               data: [
                 { correlation_id: "test-guid", use_case: "use_case_two" },
                 { error: "submitted client details could not be found in HMRC service" },
-              ]
+              ],
             }
           end
           run_test! do |response|
@@ -186,7 +186,7 @@ RSpec.describe "GET submission", type: :request, swagger_doc: "v1/swagger.yaml" 
             {
               submission: id,
               status: "processing",
-              _links: [href: "http://www.example.com/api/v1/submission/status/#{id}"]
+              _links: [href: "http://www.example.com/api/v1/submission/status/#{id}"],
             }
           end
           run_test! do |response|
@@ -202,7 +202,7 @@ RSpec.describe "GET submission", type: :request, swagger_doc: "v1/swagger.yaml" 
               submission: id,
               status: "completed",
               code: "INCOMPLETE_SUBMISSION",
-              message: "Process complete but no result available"
+              message: "Process complete but no result available",
             }
           end
           run_test! do

--- a/spec/requests/api/v1/submissions_swagger_spec.rb
+++ b/spec/requests/api/v1/submissions_swagger_spec.rb
@@ -1,40 +1,40 @@
-require 'rails_helper'
-require 'swagger_helper'
+require "rails_helper"
+require "swagger_helper"
 
-RSpec.describe 'GET submission', type: :request, swagger_doc: 'v1/swagger.yaml' do
+RSpec.describe "GET submission", type: :request, swagger_doc: "v1/swagger.yaml" do
   include AuthorisedRequestHelper
 
   let(:token) { application.access_tokens.create! }
   let(:Authorization) { "Bearer #{token.token}" }
 
-  context 'when create is called' do
+  context "when create is called" do
     let(:application) { dk_application }
-    let(:use_case) { 'one' }
+    let(:use_case) { "one" }
     let(:submission) do
       {
         filter: {
-          use_case: 'one',
-          last_name: 'Yorke',
-          first_name: 'Langley',
-          nino: 'MN212451D',
-          dob: '1992-07-22',
-          start_date: '2020-08-01',
-          end_date: '2020-10-01'
+          use_case: "one",
+          last_name: "Yorke",
+          first_name: "Langley",
+          nino: "MN212451D",
+          dob: "1992-07-22",
+          start_date: "2020-08-01",
+          end_date: "2020-10-01"
         }
       }
     end
 
-    path '/api/v1/submission/create/{use_case}' do
-      post('Create new submission') do
-        tags 'Submissions'
-        produces 'application/json'
-        consumes 'application/json'
+    path "/api/v1/submission/create/{use_case}" do
+      post("Create new submission") do
+        tags "Submissions"
+        produces "application/json"
+        consumes "application/json"
         security [{ oAuth: [] }]
         parameter name: :use_case,
                   in: :path,
                   required: true,
                   type: :string,
-                  description: 'The use case you wish to request',
+                  description: "The use case you wish to request",
                   schema: { enum: %w[one two three four] }
         parameter name: :submission,
                   in: :body,
@@ -45,60 +45,60 @@ RSpec.describe 'GET submission', type: :request, swagger_doc: 'v1/swagger.yaml' 
                       filter: {
                         type: :object,
                         properties: {
-                          first_name: { type: String, example: 'Langley' },
-                          last_name: { type: String, example: 'Yorke' },
-                          nino: { type: String, example: 'MN212451D' },
-                          dob: { type: Date, example: '1992-07-22' },
-                          start_date: { type: Date, example: '2020-08-01' },
-                          end_date: { type: Date, example: '2020-10-01' }
+                          first_name: { type: String, example: "Langley" },
+                          last_name: { type: String, example: "Yorke" },
+                          nino: { type: String, example: "MN212451D" },
+                          dob: { type: Date, example: "1992-07-22" },
+                          start_date: { type: Date, example: "2020-08-01" },
+                          end_date: { type: Date, example: "2020-10-01" }
                         }
                       }
                     }
                   }
-        response(202, 'Accepted') do
-          description 'Create a submission record and start the HMRC process asynchronously'
+        response(202, "Accepted") do
+          description "Create a submission record and start the HMRC process asynchronously"
           after do |example|
             example.metadata[:response][:content] = {
-              'application/json' => {
+              "application/json" => {
                 example: JSON.parse(response.body, symbolize_names: true)
               }
             }
           end
 
           run_test! do |response|
-            expect(response.media_type).to eq('application/json')
+            expect(response.media_type).to eq("application/json")
             expect(response.body).to match(/id/)
             expect(response.body).to match(/_links/)
-            expect(JSON.parse(response.body)['_links'].first['href']).to match(%r{http://www.example.com/api/v1/submission/result/})
+            expect(JSON.parse(response.body)["_links"].first["href"]).to match(%r{http://www.example.com/api/v1/submission/result/})
           end
         end
 
-        response(401, 'Error: Unauthorized') do
+        response(401, "Error: Unauthorized") do
           let(:Authorization) { nil }
 
           run_test!
         end
 
-        context 'when use_case is bad' do
-          response(400, 'Bad request') do
+        context "when use_case is bad" do
+          response(400, "Bad request") do
             let(:application) { dk_application(%w[use_case_three]) }
 
             run_test! do |response|
-              expect(response.media_type).to eq('application/json')
+              expect(response.media_type).to eq("application/json")
               expect(response.body).to match(/Unauthorised use case/)
             end
           end
         end
 
-        context 'when data is bad' do
-          response(400, 'Bad request') do
+        context "when data is bad" do
+          response(400, "Bad request") do
             let(:submission) do
               {
                 filter: {
                   last_name: nil,
                   first_name: nil,
-                  nino: 'abc123',
-                  dob: '1234',
+                  nino: "abc123",
+                  dob: "1234",
                   start_date: nil,
                   end_date: nil
                 }
@@ -106,24 +106,24 @@ RSpec.describe 'GET submission', type: :request, swagger_doc: 'v1/swagger.yaml' 
             end
             run_test! do |response|
               errors = JSON.parse(response.body)
-              expect(response.media_type).to eq('application/json')
-              expect(errors['first_name']).to eq(["can't be blank"])
-              expect(errors['last_name']).to eq(["can't be blank"])
-              expect(errors['nino']).to eq(['is not valid'])
-              expect(errors['dob']).to eq(['is not a valid date'])
-              expect(errors['start_date']).to eq(['is not a valid date'])
-              expect(errors['end_date']).to eq(['is not a valid date'])
+              expect(response.media_type).to eq("application/json")
+              expect(errors["first_name"]).to eq(["can't be blank"])
+              expect(errors["last_name"]).to eq(["can't be blank"])
+              expect(errors["nino"]).to eq(["is not valid"])
+              expect(errors["dob"]).to eq(["is not a valid date"])
+              expect(errors["start_date"]).to eq(["is not a valid date"])
+              expect(errors["end_date"]).to eq(["is not a valid date"])
             end
           end
         end
 
-        context 'when scope is invalid' do
-          response(400, 'Bad request') do
-            let(:use_case) { 'three' }
+        context "when scope is invalid" do
+          response(400, "Bad request") do
+            let(:use_case) { "three" }
             let(:application) { dk_application(%w[use_case_one use_case_two]) }
 
             run_test! do |response|
-              expect(response.media_type).to eq('application/json')
+              expect(response.media_type).to eq("application/json")
               expect(response.body).to match(/Unauthorised use case/)
             end
           end
@@ -132,105 +132,105 @@ RSpec.describe 'GET submission', type: :request, swagger_doc: 'v1/swagger.yaml' 
     end
   end
 
-  context 'when result is called' do
+  context "when result is called" do
     let(:application) { dk_application }
     let(:id) { submission.id }
 
-    path '/api/v1/submission/result/{id}' do
-      get 'Retrieves a submission' do
-        tags 'Submissions'
-        produces 'application/json'
-        consumes 'application/json'
+    path "/api/v1/submission/result/{id}" do
+      get "Retrieves a submission" do
+        tags "Submissions"
+        produces "application/json"
+        consumes "application/json"
         security [{ oAuth: [] }]
         parameter name: :id, in: :path, type: :string
 
-        response 200, 'Submission complete' do
+        response 200, "Submission complete" do
           let!(:submission) { create :submission, :completed, :with_attachment, oauth_application: application }
           let(:expected_response) do
             {
-              submission: 'test-guid',
-              status: 'completed',
+              submission: "test-guid",
+              status: "completed",
               data: [
-                { correlation_id: 'test-guid', use_case: 'use_case_two' },
-                { test_key: 'test value' },
+                { correlation_id: "test-guid", use_case: "use_case_two" },
+                { test_key: "test value" },
               ]
             }
           end
           run_test! do |response|
-            expect(response.media_type).to eq('application/json')
+            expect(response.media_type).to eq("application/json")
             expect(JSON.parse(response.body).deep_symbolize_keys).to eq(expected_response)
           end
         end
 
-        response 200, 'Submission failed' do
+        response 200, "Submission failed" do
           let!(:submission) { create :submission, :failed_with_attachment, oauth_application: application }
           let(:expected_response) do
             {
-              submission: 'test-guid',
-              status: 'failed',
+              submission: "test-guid",
+              status: "failed",
               data: [
-                { correlation_id: 'test-guid', use_case: 'use_case_two' },
-                { error: 'submitted client details could not be found in HMRC service' },
+                { correlation_id: "test-guid", use_case: "use_case_two" },
+                { error: "submitted client details could not be found in HMRC service" },
               ]
             }
           end
           run_test! do |response|
-            expect(response.media_type).to eq('application/json')
+            expect(response.media_type).to eq("application/json")
             expect(JSON.parse(response.body).deep_symbolize_keys).to eq(expected_response)
           end
         end
 
-        response 202, 'Submission still processing' do
+        response 202, "Submission still processing" do
           let!(:submission) { create :submission, :processing, oauth_application: application }
           let(:expected_response) do
             {
               submission: id,
-              status: 'processing',
+              status: "processing",
               _links: [href: "http://www.example.com/api/v1/submission/status/#{id}"]
             }
           end
           run_test! do |response|
-            expect(response.media_type).to eq('application/json')
+            expect(response.media_type).to eq("application/json")
             expect(JSON.parse(response.body, symbolize_names: true)).to eq(expected_response)
           end
         end
 
-        response 500, 'Submission complete but no result object is present' do
+        response 500, "Submission complete but no result object is present" do
           let!(:submission) { create :submission, :completed, oauth_application: application }
           let(:expected_response) do
             {
               submission: id,
-              status: 'completed',
-              code: 'INCOMPLETE_SUBMISSION',
-              message: 'Process complete but no result available'
+              status: "completed",
+              code: "INCOMPLETE_SUBMISSION",
+              message: "Process complete but no result available"
             }
           end
           run_test! do
-            expect(response.media_type).to eq('application/json')
+            expect(response.media_type).to eq("application/json")
             expect(JSON.parse(response.body).symbolize_keys).to eq(expected_response)
           end
         end
 
-        response 404, 'Submission not found' do
-          let(:id) { '1234' }
+        response 404, "Submission not found" do
+          let(:id) { "1234" }
           run_test!
         end
 
-        response 401, 'Error: Unauthorized' do
-          let(:id) { '1234' }
+        response 401, "Error: Unauthorized" do
+          let(:id) { "1234" }
           let(:Authorization) { nil }
           run_test!
         end
 
-        context 'when application is not the application that created the submission' do
-          response(400, 'Bad request') do
+        context "when application is not the application that created the submission" do
+          response(400, "Bad request") do
             let(:submitting_application) { dk_application }
             let(:submission) do
               create :submission, :processing, oauth_application: submitting_application
             end
 
             run_test! do |response|
-              expect(response.media_type).to eq('application/json')
+              expect(response.media_type).to eq("application/json")
               expect(response.body).to match(/Unauthorised application/)
             end
           end

--- a/spec/requests/main_controller_spec.rb
+++ b/spec/requests/main_controller_spec.rb
@@ -1,13 +1,13 @@
-require 'rails_helper'
+require "rails_helper"
 
 describe MainController, type: :request do
-  describe 'GET /main' do
+  describe "GET /main" do
     subject(:get_main) { get main_path }
 
     before { get_main }
 
-    it 'redirects to the rswag documentation' do
-      expect(response).to redirect_to('/api-docs')
+    it "redirects to the rswag documentation" do
+      expect(response).to redirect_to("/api-docs")
     end
   end
 end

--- a/spec/requests/sidekiq_spec.rb
+++ b/spec/requests/sidekiq_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe "sidekiq WEB UI", type: :request do
         username = Settings.sidekiq.username
         password = Settings.sidekiq.web_ui_password
         get sidekiq_web_path, headers: {
-          "HTTP_AUTHORIZATION" => ActionController::HttpAuthentication::Basic.encode_credentials(username, password)
+          "HTTP_AUTHORIZATION" => ActionController::HttpAuthentication::Basic.encode_credentials(username, password),
         }
         expect(response).to have_http_status(:ok)
       end

--- a/spec/requests/sidekiq_spec.rb
+++ b/spec/requests/sidekiq_spec.rb
@@ -1,19 +1,19 @@
-require 'rails_helper'
+require "rails_helper"
 
-RSpec.describe 'sidekiq WEB UI', type: :request do
-  describe 'GET /sidekiq' do
-    it 'returns unauthorized status' do
+RSpec.describe "sidekiq WEB UI", type: :request do
+  describe "GET /sidekiq" do
+    it "returns unauthorized status" do
       get sidekiq_web_path
 
       expect(response).to have_http_status(:unauthorized)
     end
 
-    context 'with the right authentication' do
-      it 'is successful' do
+    context "with the right authentication" do
+      it "is successful" do
         username = Settings.sidekiq.username
         password = Settings.sidekiq.web_ui_password
         get sidekiq_web_path, headers: {
-          'HTTP_AUTHORIZATION' => ActionController::HttpAuthentication::Basic.encode_credentials(username, password)
+          "HTTP_AUTHORIZATION" => ActionController::HttpAuthentication::Basic.encode_credentials(username, password)
         }
         expect(response).to have_http_status(:ok)
       end

--- a/spec/requests/smoke_test_swagger_spec.rb
+++ b/spec/requests/smoke_test_swagger_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe "smoke_test", type: :request, swagger_doc: "v1/swagger.yaml" do
       parameter name: :use_case, in: :path, type: :string
       response(200, "success") do
         examples "application/json" => {
-          smoke_test_one_result: true
+          smoke_test_one_result: true,
         }
         run_test!
       end
@@ -28,7 +28,7 @@ RSpec.describe "smoke_test", type: :request, swagger_doc: "v1/swagger.yaml" do
         let(:success) { false }
 
         examples "application/json" => {
-          smoke_test_one_result: false
+          smoke_test_one_result: false,
         }
         run_test!
       end
@@ -57,8 +57,8 @@ RSpec.describe "smoke_test", type: :request, swagger_doc: "v1/swagger.yaml" do
               use_case_one: true,
               use_case_two: true,
               use_case_three: true,
-              use_case_four: true
-            }
+              use_case_four: true,
+            },
         }
         run_test!
       end
@@ -71,8 +71,8 @@ RSpec.describe "smoke_test", type: :request, swagger_doc: "v1/swagger.yaml" do
               use_case_one: false,
               use_case_two: true,
               use_case_three: true,
-              use_case_four: true
-            }
+              use_case_four: true,
+            },
         }
         run_test!
       end

--- a/spec/requests/smoke_test_swagger_spec.rb
+++ b/spec/requests/smoke_test_swagger_spec.rb
@@ -1,9 +1,9 @@
-require 'swagger_helper'
+require "swagger_helper"
 
-RSpec.describe 'smoke_test', type: :request, swagger_doc: 'v1/swagger.yaml' do
-  let(:use_case) { 'one' }
+RSpec.describe "smoke_test", type: :request, swagger_doc: "v1/swagger.yaml" do
+  let(:use_case) { "one" }
 
-  path '/smoke-test/{use_case}' do
+  path "/smoke-test/{use_case}" do
     let(:smoke_test) { instance_double(SmokeTest) }
     let(:success) { true }
 
@@ -12,22 +12,22 @@ RSpec.describe 'smoke_test', type: :request, swagger_doc: 'v1/swagger.yaml' do
       allow(smoke_test).to receive(:call).and_return(success)
     end
 
-    get('individual use_case smoke-test') do
-      description 'Run a smoke test for chosen use_case'
-      tags 'Smoke tests'
-      consumes 'application/json'
-      produces 'application/json'
+    get("individual use_case smoke-test") do
+      description "Run a smoke test for chosen use_case"
+      tags "Smoke tests"
+      consumes "application/json"
+      produces "application/json"
       parameter name: :use_case, in: :path, type: :string
-      response(200, 'success') do
-        examples 'application/json' => {
+      response(200, "success") do
+        examples "application/json" => {
           smoke_test_one_result: true
         }
         run_test!
       end
-      response(500, 'internal server error') do
+      response(500, "internal server error") do
         let(:success) { false }
 
-        examples 'application/json' => {
+        examples "application/json" => {
           smoke_test_one_result: false
         }
         run_test!
@@ -35,23 +35,23 @@ RSpec.describe 'smoke_test', type: :request, swagger_doc: 'v1/swagger.yaml' do
     end
   end
 
-  path '/smoke-test' do
+  path "/smoke-test" do
     before do
-      allow(REDIS).to receive(:get).with('smoke-test-one').and_return(test_one_result)
-      allow(REDIS).to receive(:get).with('smoke-test-two').and_return(true)
-      allow(REDIS).to receive(:get).with('smoke-test-three').and_return(true)
-      allow(REDIS).to receive(:get).with('smoke-test-four').and_return(true)
+      allow(REDIS).to receive(:get).with("smoke-test-one").and_return(test_one_result)
+      allow(REDIS).to receive(:get).with("smoke-test-two").and_return(true)
+      allow(REDIS).to receive(:get).with("smoke-test-three").and_return(true)
+      allow(REDIS).to receive(:get).with("smoke-test-four").and_return(true)
     end
 
     let(:test_one_result) { true }
 
-    get('call smoke_test') do
-      description 'Fetch smoke_test results that have been generated within the last hour'
-      tags 'Smoke tests'
-      consumes 'application/json'
-      produces 'application/json'
-      response(200, 'success') do
-        examples 'application/json' => {
+    get("call smoke_test") do
+      description "Fetch smoke_test results that have been generated within the last hour"
+      tags "Smoke tests"
+      consumes "application/json"
+      produces "application/json"
+      response(200, "success") do
+        examples "application/json" => {
           smoke_test_result:
             {
               use_case_one: true,
@@ -63,9 +63,9 @@ RSpec.describe 'smoke_test', type: :request, swagger_doc: 'v1/swagger.yaml' do
         run_test!
       end
 
-      response(500, 'internal server error') do
+      response(500, "internal server error") do
         let(:test_one_result) { false }
-        examples 'application/json' => {
+        examples "application/json" => {
           smoke_test_result:
             {
               use_case_one: false,

--- a/spec/requests/status_controller_spec.rb
+++ b/spec/requests/status_controller_spec.rb
@@ -21,8 +21,8 @@ RSpec.describe StatusController, type: :request do
             database: false,
             redis: true,
             sidekiq: true,
-            sidekiq_queue: true
-          }
+            sidekiq_queue: true,
+          },
         }.to_json
       end
 
@@ -48,8 +48,8 @@ RSpec.describe StatusController, type: :request do
             database: true,
             redis: false,
             sidekiq: true,
-            sidekiq_queue: true
-          }
+            sidekiq_queue: true,
+          },
         }.to_json
       end
 
@@ -80,8 +80,8 @@ RSpec.describe StatusController, type: :request do
             database: true,
             redis: false,
             sidekiq: false,
-            sidekiq_queue: true
-          }
+            sidekiq_queue: true,
+          },
         }.to_json
       end
 
@@ -101,8 +101,8 @@ RSpec.describe StatusController, type: :request do
             database: true,
             redis: true,
             sidekiq: true,
-            sidekiq_queue: false
-          }
+            sidekiq_queue: false,
+          },
         }.to_json
       end
 
@@ -150,8 +150,8 @@ RSpec.describe StatusController, type: :request do
             database: true,
             redis: true,
             sidekiq: false,
-            sidekiq_queue: true
-          }
+            sidekiq_queue: true,
+          },
         }.to_json
       end
 
@@ -177,8 +177,8 @@ RSpec.describe StatusController, type: :request do
             database: true,
             redis: true,
             sidekiq: true,
-            sidekiq_queue: false
-          }
+            sidekiq_queue: false,
+          },
         }.to_json
       end
 
@@ -205,8 +205,8 @@ RSpec.describe StatusController, type: :request do
             database: true,
             redis: true,
             sidekiq: true,
-            sidekiq_queue: true
-          }
+            sidekiq_queue: true,
+          },
         }.to_json
       end
 
@@ -228,7 +228,7 @@ RSpec.describe StatusController, type: :request do
         {
           "build_date" => "20150721",
           "build_tag" => "test",
-          "app_branch" => "test_branch"
+          "app_branch" => "test_branch",
         }
       end
 

--- a/spec/requests/status_controller_spec.rb
+++ b/spec/requests/status_controller_spec.rb
@@ -1,18 +1,18 @@
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe StatusController, type: :request do
-  describe '#healthcheck' do
+  describe "#healthcheck" do
     before do
       allow(Sidekiq::ProcessSet).to receive(:new).and_return(instance_double(Sidekiq::ProcessSet, size: 1))
       allow(Sidekiq::RetrySet).to receive(:new).and_return(instance_double(Sidekiq::RetrySet, size: 0))
       allow(Sidekiq::DeadSet).to receive(:new).and_return(instance_double(Sidekiq::DeadSet, size: 0))
     end
 
-    context 'when an postgres problem exists' do
+    context "when an postgres problem exists" do
       before do
         allow(ActiveRecord::Base.connection).to receive(:active?).and_raise(PG::ConnectionBad)
 
-        get '/health_check'
+        get "/health_check"
       end
 
       let(:failed_healthcheck) do
@@ -26,20 +26,20 @@ RSpec.describe StatusController, type: :request do
         }.to_json
       end
 
-      it 'returns status bad gateway' do
+      it "returns status bad gateway" do
         expect(response).to have_http_status :bad_gateway
       end
 
-      it 'returns the expected response report' do
+      it "returns the expected response report" do
         expect(response.body).to eq(failed_healthcheck)
       end
     end
 
-    context 'when a redis problem exists' do
+    context "when a redis problem exists" do
       before do
         allow(REDIS).to receive(:ping).and_raise(Redis::CannotConnectError)
 
-        get '/health_check'
+        get "/health_check"
       end
 
       let(:failed_healthcheck) do
@@ -53,25 +53,25 @@ RSpec.describe StatusController, type: :request do
         }.to_json
       end
 
-      it 'returns status bad gateway' do
+      it "returns status bad gateway" do
         expect(response).to have_http_status :bad_gateway
       end
 
-      it 'returns the expected response report' do
+      it "returns the expected response report" do
         expect(response.body).to eq(failed_healthcheck)
       end
     end
 
-    context 'when a sidekiq problem exists' do
+    context "when a sidekiq problem exists" do
       before do
         allow(REDIS).to receive(:ping).and_raise(Redis::CannotConnectError)
         allow(Sidekiq::ProcessSet).to receive(:new).and_return(instance_double(Sidekiq::ProcessSet, size: 0))
 
-        connection = instance_double('connection')
+        connection = instance_double("connection")
         allow(connection).to receive(:info).and_raise(Redis::CannotConnectError)
         allow(Sidekiq).to receive(:redis).and_yield(connection)
 
-        get '/health_check'
+        get "/health_check"
       end
 
       let(:failed_healthcheck) do
@@ -85,16 +85,16 @@ RSpec.describe StatusController, type: :request do
         }.to_json
       end
 
-      it 'returns status bad gateway' do
+      it "returns status bad gateway" do
         expect(response).to have_http_status :bad_gateway
       end
 
-      it 'returns the expected response report' do
+      it "returns the expected response report" do
         expect(response.body).to eq(failed_healthcheck)
       end
     end
 
-    context 'when failed Sidekiq jobs exist' do
+    context "when failed Sidekiq jobs exist" do
       let(:failed_job_health_check) do
         {
           checks: {
@@ -106,42 +106,42 @@ RSpec.describe StatusController, type: :request do
         }.to_json
       end
 
-      context 'and dead set exists' do
+      context "and dead set exists" do
         before do
           allow(Sidekiq::DeadSet).to receive(:new).and_return(instance_double(Sidekiq::DeadSet, size: 1))
-          get '/health_check'
+          get "/health_check"
         end
 
-        it 'returns ok http status' do
+        it "returns ok http status" do
           expect(response).to have_http_status :ok
         end
 
-        it 'returns the expected response report' do
+        it "returns the expected response report" do
           expect(response.body).to eq(failed_job_health_check)
         end
       end
 
-      context 'and retry set exists' do
+      context "and retry set exists" do
         before do
           allow(Sidekiq::RetrySet).to receive(:new).and_return(instance_double(Sidekiq::RetrySet, size: 1))
-          get '/health_check'
+          get "/health_check"
         end
 
-        it 'returns ok http status' do
+        it "returns ok http status" do
           expect(response).to have_http_status :ok
         end
 
-        it 'returns the expected response report' do
+        it "returns the expected response report" do
           expect(response.body).to eq(failed_job_health_check)
         end
       end
     end
 
-    context 'when Sidekiq::ProcessSet encounters an error' do
+    context "when Sidekiq::ProcessSet encounters an error" do
       before do
         allow(Sidekiq::ProcessSet).to receive(:new).and_raise(StandardError)
 
-        get '/health_check'
+        get "/health_check"
       end
 
       let(:failed_health_check) do
@@ -155,20 +155,20 @@ RSpec.describe StatusController, type: :request do
         }.to_json
       end
 
-      it 'returns status bad gateway' do
+      it "returns status bad gateway" do
         expect(response).to have_http_status :bad_gateway
       end
 
-      it 'returns the expected response report' do
+      it "returns the expected response report" do
         expect(response.body).to eq(failed_health_check)
       end
     end
 
-    context 'when sidekiq_queue_healthy encounters an error' do
+    context "when sidekiq_queue_healthy encounters an error" do
       before do
         allow(Sidekiq::DeadSet).to receive(:new).and_raise(StandardError)
 
-        get '/health_check'
+        get "/health_check"
       end
 
       let(:failed_health_check) do
@@ -182,21 +182,21 @@ RSpec.describe StatusController, type: :request do
         }.to_json
       end
 
-      it 'returns ok http status' do
+      it "returns ok http status" do
         # queue health should not impact the status
         expect(response).to have_http_status :ok
       end
 
-      it 'returns the expected response report' do
+      it "returns the expected response report" do
         expect(response.body).to eq(failed_health_check)
       end
     end
 
-    context 'when everything is ok' do
+    context "when everything is ok" do
       before do
         allow(ActiveRecord::Base.connection).to receive(:active?).and_return(true)
 
-        get '/health_check'
+        get "/health_check"
       end
 
       let(:expected_response) do
@@ -210,52 +210,52 @@ RSpec.describe StatusController, type: :request do
         }.to_json
       end
 
-      it 'returns HTTP success' do
-        get '/health_check'
+      it "returns HTTP success" do
+        get "/health_check"
         expect(response.status).to eq(200)
       end
 
-      it 'returns the expected response report' do
-        get '/health_check'
+      it "returns the expected response report" do
+        get "/health_check"
         expect(response.body).to eq(expected_response)
       end
     end
   end
 
-  describe '#ping' do
-    context 'when environment variables set' do
+  describe "#ping" do
+    context "when environment variables set" do
       let(:expected_json) do
         {
-          'build_date' => '20150721',
-          'build_tag' => 'test',
-          'app_branch' => 'test_branch'
+          "build_date" => "20150721",
+          "build_tag" => "test",
+          "app_branch" => "test_branch"
         }
       end
 
       before do
-        allow(Settings.status).to receive(:build_date).and_return('20150721')
-        allow(Settings.status).to receive(:build_tag).and_return('test')
-        allow(Settings.status).to receive(:app_branch).and_return('test_branch')
+        allow(Settings.status).to receive(:build_date).and_return("20150721")
+        allow(Settings.status).to receive(:build_tag).and_return("test")
+        allow(Settings.status).to receive(:app_branch).and_return("test_branch")
 
-        get('/ping')
+        get("/ping")
       end
 
-      it 'returns JSON with app information' do
+      it "returns JSON with app information" do
         expect(JSON.parse(response.body)).to eq(expected_json)
       end
     end
 
-    context 'when environment variables not set' do
+    context "when environment variables not set" do
       before do
-        allow(Settings.status).to receive(:build_date).and_return('Not Available')
-        allow(Settings.status).to receive(:build_tag).and_return('Not Available')
-        allow(Settings.status).to receive(:app_branch).and_return('Not Available')
+        allow(Settings.status).to receive(:build_date).and_return("Not Available")
+        allow(Settings.status).to receive(:build_tag).and_return("Not Available")
+        allow(Settings.status).to receive(:app_branch).and_return("Not Available")
 
-        get '/ping'
+        get "/ping"
       end
 
       it 'returns "Not Available"' do
-        expect(JSON.parse(response.body).values).to be_all('Not Available')
+        expect(JSON.parse(response.body).values).to be_all("Not Available")
       end
     end
   end

--- a/spec/services/bearer_token_spec.rb
+++ b/spec/services/bearer_token_spec.rb
@@ -6,7 +6,7 @@ describe BearerToken do
   let(:fake_data) do
     {
       access_token: "zz00000z00z0z00000z0z0z0000z0000",
-      token_type: "bearer"
+      token_type: "bearer",
       # real response has other returns but out of scope of this test
     }.to_json
   end

--- a/spec/services/bearer_token_spec.rb
+++ b/spec/services/bearer_token_spec.rb
@@ -1,85 +1,85 @@
-require 'rails_helper'
+require "rails_helper"
 
 describe BearerToken do
   subject(:bearer_token) { described_class.new(use_case) }
 
   let(:fake_data) do
     {
-      access_token: 'zz00000z00z0z00000z0z0z0000z0000',
-      token_type: 'bearer'
+      access_token: "zz00000z00z0z00000z0z0z0000z0000",
+      token_type: "bearer"
       # real response has other returns but out of scope of this test
     }.to_json
   end
 
-  context 'when called with an invalid use_case' do
-    subject(:bearer_token) { described_class.new('not_a_use_case') }
+  context "when called with an invalid use_case" do
+    subject(:bearer_token) { described_class.new("not_a_use_case") }
 
-    it { expect { bearer_token }.to raise_error 'Unsupported UseCase' }
+    it { expect { bearer_token }.to raise_error "Unsupported UseCase" }
   end
 
-  context 'and UseCase one is passed' do
-    let(:use_case) { 'use_case_one' }
+  context "and UseCase one is passed" do
+    let(:use_case) { "use_case_one" }
 
     before do
       stub_request(:post, %r{\A#{Settings.credentials.use_case_one.host}/oauth/token\z})
         .to_return(status: 200, body: fake_data)
     end
 
-    describe '#call' do
+    describe "#call" do
       subject(:call) { bearer_token.call }
 
-      it { is_expected.to eql 'zz00000z00z0z00000z0z0z0000z0000' }
+      it { is_expected.to eql "zz00000z00z0z00000z0z0z0000z0000" }
     end
 
-    describe '.call' do
-      subject(:call) { described_class.call('use_case_one') }
+    describe ".call" do
+      subject(:call) { described_class.call("use_case_one") }
 
-      it { is_expected.to eql 'zz00000z00z0z00000z0z0z0000z0000' }
+      it { is_expected.to eql "zz00000z00z0z00000z0z0z0000z0000" }
     end
   end
 
-  context 'and UseCase two is passed' do
-    let(:use_case) { 'use_case_two' }
+  context "and UseCase two is passed" do
+    let(:use_case) { "use_case_two" }
 
     before do
       stub_request(:post, %r{\A#{Settings.credentials.use_case_two.host}/oauth/token\z})
         .to_return(status: 200, body: fake_data)
     end
 
-    describe '#call' do
+    describe "#call" do
       subject(:call) { bearer_token.call }
 
-      it { is_expected.to eql 'zz00000z00z0z00000z0z0z0000z0000' }
+      it { is_expected.to eql "zz00000z00z0z00000z0z0z0000z0000" }
     end
   end
 
-  context 'and UseCase three is passed' do
-    let(:use_case) { 'use_case_three' }
+  context "and UseCase three is passed" do
+    let(:use_case) { "use_case_three" }
 
     before do
       stub_request(:post, %r{\A#{Settings.credentials.use_case_three.host}/oauth/token\z})
         .to_return(status: 200, body: fake_data)
     end
 
-    describe '#call' do
+    describe "#call" do
       subject(:call) { bearer_token.call }
 
-      it { is_expected.to eql 'zz00000z00z0z00000z0z0z0000z0000' }
+      it { is_expected.to eql "zz00000z00z0z00000z0z0z0000z0000" }
     end
   end
 
-  context 'and UseCase four is passed' do
-    let(:use_case) { 'use_case_four' }
+  context "and UseCase four is passed" do
+    let(:use_case) { "use_case_four" }
 
     before do
       stub_request(:post, %r{\A#{Settings.credentials.use_case_four.host}/oauth/token\z})
         .to_return(status: 200, body: fake_data)
     end
 
-    describe '#call' do
+    describe "#call" do
       subject(:call) { bearer_token.call }
 
-      it { is_expected.to eql 'zz00000z00z0z00000z0z0z0000z0000' }
+      it { is_expected.to eql "zz00000z00z0z00000z0z0z0000z0000" }
     end
   end
 end

--- a/spec/services/endpoint/headers_spec.rb
+++ b/spec/services/endpoint/headers_spec.rb
@@ -1,22 +1,22 @@
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe Endpoint::Headers do
   subject(:headers) { described_class.new(href, correlation_id, token) }
 
-  let(:correlation_id) { 'fake-correlation_id' }
-  let(:token) { 'fake_bearer_token' }
+  let(:correlation_id) { "fake-correlation_id" }
+  let(:token) { "fake_bearer_token" }
 
-  describe '#call' do
+  describe "#call" do
     subject(:call) { described_class.call(href, correlation_id, token) }
 
-    context 'when there is no matchID' do
-      let(:href) { 'individuals/matching' }
+    context "when there is no matchID" do
+      let(:href) { "individuals/matching" }
       let(:expected_hash) do
         {
-          accept: 'application/vnd.hmrc.2.0+json',
-          content_type: 'application/json',
-          correlationId: 'fake-correlation_id',
-          Authorization: 'Bearer fake_bearer_token'
+          accept: "application/vnd.hmrc.2.0+json",
+          content_type: "application/json",
+          correlationId: "fake-correlation_id",
+          Authorization: "Bearer fake_bearer_token"
         }
       end
 
@@ -24,56 +24,56 @@ RSpec.describe Endpoint::Headers do
     end
   end
 
-  describe '.call' do
+  describe ".call" do
     subject(:call) { headers.call }
 
-    context 'when there is no matchID' do
-      let(:href) { 'individuals/matching' }
+    context "when there is no matchID" do
+      let(:href) { "individuals/matching" }
       let(:expected_hash) do
         {
-          accept: 'application/vnd.hmrc.2.0+json',
-          content_type: 'application/json',
-          correlationId: 'fake-correlation_id',
-          Authorization: 'Bearer fake_bearer_token'
+          accept: "application/vnd.hmrc.2.0+json",
+          content_type: "application/json",
+          correlationId: "fake-correlation_id",
+          Authorization: "Bearer fake_bearer_token"
         }
       end
 
       it { is_expected.to eql expected_hash }
     end
 
-    context 'when the url end with individuals/matching but has a uuid' do
-      let(:href) { 'individuals/matching/fake-uuid' }
+    context "when the url end with individuals/matching but has a uuid" do
+      let(:href) { "individuals/matching/fake-uuid" }
       let(:expected_hash) do
         {
-          accept: 'application/vnd.hmrc.2.0+json',
-          correlationId: 'fake-correlation_id',
-          Authorization: 'Bearer fake_bearer_token'
+          accept: "application/vnd.hmrc.2.0+json",
+          correlationId: "fake-correlation_id",
+          Authorization: "Bearer fake_bearer_token"
         }
       end
 
       it { is_expected.to eql expected_hash }
     end
 
-    context 'when the url includes benefits-and-credits' do
-      let(:href) { '/root/benefits-and-credits/sub?matchId=fake-uuid' }
+    context "when the url includes benefits-and-credits" do
+      let(:href) { "/root/benefits-and-credits/sub?matchId=fake-uuid" }
       let(:expected_hash) do
         {
-          accept: 'application/vnd.hmrc.1.0+json',
-          correlationId: 'fake-correlation_id',
-          Authorization: 'Bearer fake_bearer_token'
+          accept: "application/vnd.hmrc.1.0+json",
+          correlationId: "fake-correlation_id",
+          Authorization: "Bearer fake_bearer_token"
         }
       end
 
       it { is_expected.to eql expected_hash }
     end
 
-    context 'when the url does not include benefits-and-credits' do
-      let(:href) { '/root/employment?matchId=fake-uuid' }
+    context "when the url does not include benefits-and-credits" do
+      let(:href) { "/root/employment?matchId=fake-uuid" }
       let(:expected_hash) do
         {
-          accept: 'application/vnd.hmrc.2.0+json',
-          correlationId: 'fake-correlation_id',
-          Authorization: 'Bearer fake_bearer_token'
+          accept: "application/vnd.hmrc.2.0+json",
+          correlationId: "fake-correlation_id",
+          Authorization: "Bearer fake_bearer_token"
         }
       end
 

--- a/spec/services/endpoint/headers_spec.rb
+++ b/spec/services/endpoint/headers_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Endpoint::Headers do
           accept: "application/vnd.hmrc.2.0+json",
           content_type: "application/json",
           correlationId: "fake-correlation_id",
-          Authorization: "Bearer fake_bearer_token"
+          Authorization: "Bearer fake_bearer_token",
         }
       end
 
@@ -34,7 +34,7 @@ RSpec.describe Endpoint::Headers do
           accept: "application/vnd.hmrc.2.0+json",
           content_type: "application/json",
           correlationId: "fake-correlation_id",
-          Authorization: "Bearer fake_bearer_token"
+          Authorization: "Bearer fake_bearer_token",
         }
       end
 
@@ -47,7 +47,7 @@ RSpec.describe Endpoint::Headers do
         {
           accept: "application/vnd.hmrc.2.0+json",
           correlationId: "fake-correlation_id",
-          Authorization: "Bearer fake_bearer_token"
+          Authorization: "Bearer fake_bearer_token",
         }
       end
 
@@ -60,7 +60,7 @@ RSpec.describe Endpoint::Headers do
         {
           accept: "application/vnd.hmrc.1.0+json",
           correlationId: "fake-correlation_id",
-          Authorization: "Bearer fake_bearer_token"
+          Authorization: "Bearer fake_bearer_token",
         }
       end
 
@@ -73,7 +73,7 @@ RSpec.describe Endpoint::Headers do
         {
           accept: "application/vnd.hmrc.2.0+json",
           correlationId: "fake-correlation_id",
-          Authorization: "Bearer fake_bearer_token"
+          Authorization: "Bearer fake_bearer_token",
         }
       end
 

--- a/spec/services/endpoint/tax_years_for_spec.rb
+++ b/spec/services/endpoint/tax_years_for_spec.rb
@@ -1,21 +1,21 @@
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe Endpoint::TaxYearsFor do
   subject(:tax_year) { described_class.call(date) }
 
-  context 'when the date is at the beginning of April' do
+  context "when the date is at the beginning of April" do
     let(:date) { Date.new(2021, 4, 3) }
 
-    it 'returns the previous year to the current year' do
-      expect(tax_year).to eql '2020-21'
+    it "returns the previous year to the current year" do
+      expect(tax_year).to eql "2020-21"
     end
   end
 
-  context 'when the date is past April' do
+  context "when the date is past April" do
     let(:date) { Date.new(2021, 5, 3) }
 
-    it 'returns the current year to next year' do
-      expect(tax_year).to eql '2021-22'
+    it "returns the current year to next year" do
+      expect(tax_year).to eql "2021-22"
     end
   end
 end

--- a/spec/services/endpoint/uri_spec.rb
+++ b/spec/services/endpoint/uri_spec.rb
@@ -1,66 +1,66 @@
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe Endpoint::Uri do
-  subject(:use_case) { described_class.new(href, use_case: 'use_case_one', from_date:, to_date:) }
+  subject(:use_case) { described_class.new(href, use_case: "use_case_one", from_date:, to_date:) }
 
-  let(:href) { '/root/type/sub?matchID=123456' }
-  let(:from_date) { '2021-01-01' }
-  let(:to_date) { '2021-03-31' }
+  let(:href) { "/root/type/sub?matchID=123456" }
+  let(:from_date) { "2021-01-01" }
+  let(:to_date) { "2021-03-31" }
 
   it { is_expected.to be_a described_class }
 
-  describe '.for_calling' do
+  describe ".for_calling" do
     subject(:for_calling) { use_case.for_calling }
 
-    context 'when the href just has a matchID' do
-      it { is_expected.to eql '/root/type/sub?matchID=123456' }
+    context "when the href just has a matchID" do
+      it { is_expected.to eql "/root/type/sub?matchID=123456" }
     end
 
-    context 'when the href has a matchID and requires dates' do
-      let(:href) { '/root/type/sub?matchID=123456{&fromDate,toDate}' }
+    context "when the href has a matchID and requires dates" do
+      let(:href) { "/root/type/sub?matchID=123456{&fromDate,toDate}" }
 
-      it { is_expected.to eql '/root/type/sub?matchID=123456&fromDate=2021-01-01&toDate=2021-03-31' }
+      it { is_expected.to eql "/root/type/sub?matchID=123456&fromDate=2021-01-01&toDate=2021-03-31" }
     end
 
-    context 'when the href has a matchID and requires tax years' do
-      let(:href) { '/root/type/sub?matchID=123456{&fromTaxYear,toTaxYear}' }
+    context "when the href has a matchID and requires tax years" do
+      let(:href) { "/root/type/sub?matchID=123456{&fromTaxYear,toTaxYear}" }
 
-      it { is_expected.to eql '/root/type/sub?matchID=123456&fromTaxYear=2020-21&toTaxYear=2020-21' }
+      it { is_expected.to eql "/root/type/sub?matchID=123456&fromTaxYear=2020-21&toTaxYear=2020-21" }
 
-      context 'when the financial years differ' do
-        let(:from_date) { '2021-02-01' }
-        let(:to_date) { '2021-04-30' }
+      context "when the financial years differ" do
+        let(:from_date) { "2021-02-01" }
+        let(:to_date) { "2021-04-30" }
 
-        it { is_expected.to eql '/root/type/sub?matchID=123456&fromTaxYear=2020-21&toTaxYear=2021-22' }
+        it { is_expected.to eql "/root/type/sub?matchID=123456&fromTaxYear=2020-21&toTaxYear=2021-22" }
       end
     end
   end
 
-  describe '.for_displaying' do
+  describe ".for_displaying" do
     subject(:for_displaying) { use_case.for_displaying }
 
-    context 'when the href just has a matchID' do
-      let(:href) { '/root/type?matchID=123456' }
+    context "when the href just has a matchID" do
+      let(:href) { "/root/type?matchID=123456" }
 
-      it { is_expected.to eql 'type' }
+      it { is_expected.to eql "type" }
     end
 
-    context 'when the href has a matchID and requires dates' do
-      let(:href) { '/root/type/sub?matchID=123456{&fromDate,toDate}' }
+    context "when the href has a matchID and requires dates" do
+      let(:href) { "/root/type/sub?matchID=123456{&fromDate,toDate}" }
 
-      it { is_expected.to eql 'type/sub' }
+      it { is_expected.to eql "type/sub" }
     end
 
-    context 'when the href has a matchID and requires tax years' do
-      let(:href) { '/root/type/sub?matchID=123456{&fromTaxYear,toTaxYear}' }
+    context "when the href has a matchID and requires tax years" do
+      let(:href) { "/root/type/sub?matchID=123456{&fromTaxYear,toTaxYear}" }
 
-      it { is_expected.to eql 'type/sub' }
+      it { is_expected.to eql "type/sub" }
     end
 
-    context 'when the href contains matching' do
-      let(:href) { '/root/matching/type/123456' }
+    context "when the href contains matching" do
+      let(:href) { "/root/matching/type/123456" }
 
-      it { is_expected.to eql 'root/matching' }
+      it { is_expected.to eql "root/matching" }
     end
   end
 end

--- a/spec/services/hmrc/sandbox/create_test_data_spec.rb
+++ b/spec/services/hmrc/sandbox/create_test_data_spec.rb
@@ -1,4 +1,4 @@
-require 'rails_helper'
+require "rails_helper"
 
 describe HMRC::Sandbox::CreateTestData do
   subject(:create_data) { described_class.new(type) }
@@ -7,37 +7,37 @@ describe HMRC::Sandbox::CreateTestData do
 
   before do
     remove_request_stub(@hmrc_stub_requests)
-    allow(REDIS).to receive(:get).with('use_case_one_bearer_token').and_return('dummy_bearer_token')
-    stub_request(:post, /\A#{Settings.credentials.host}.*\z/).to_return(status: 201, body: '', headers: {})
+    allow(REDIS).to receive(:get).with("use_case_one_bearer_token").and_return("dummy_bearer_token")
+    stub_request(:post, /\A#{Settings.credentials.host}.*\z/).to_return(status: 201, body: "", headers: {})
   end
 
-  describe '.call' do
+  describe ".call" do
     subject(:call) { create_data.call }
 
-    it 'makes a single post to the expected endpoint' do
+    it "makes a single post to the expected endpoint" do
       call
       expect(a_request(:post, /\A#{Settings.credentials.host}.*#{type}.*\z/)).to have_been_made.times(1)
     end
   end
 
-  describe '#call' do
-    subject(:call) { described_class.call(type, '2021-01-01', '2021-02-01') }
+  describe "#call" do
+    subject(:call) { described_class.call(type, "2021-01-01", "2021-02-01") }
 
     let(:type) { :employment }
 
-    it 'makes a single post to the expected endpoint' do
+    it "makes a single post to the expected endpoint" do
       call
       expect(a_request(:post, /\A#{Settings.credentials.host}.*#{type}.*\z/)).to have_been_made.times(1)
     end
   end
 
-  context 'when called on production' do
-    before { allow(Settings).to receive(:environment).and_return('production') }
+  context "when called on production" do
+    before { allow(Settings).to receive(:environment).and_return("production") }
 
     it { expect { create_data }.to raise_error HMRC::Sandbox::ProductionError }
   end
 
-  context 'when the type is invalid' do
+  context "when the type is invalid" do
     let(:type) { :tax_credit }
 
     it { expect { create_data }.to raise_error HMRC::Sandbox::TypeError }

--- a/spec/services/queue_name_service_spec.rb
+++ b/spec/services/queue_name_service_spec.rb
@@ -1,27 +1,27 @@
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe QueueNameService do
-  describe '.call' do
+  describe ".call" do
     subject(:call) { described_class.call }
 
-    context 'when the service is called in UAT' do
+    context "when the service is called in UAT" do
       before do
-        Settings.sentry.environment = 'uat'
-        Settings.status.app_branch = 'this-is/a.test-branch'
+        Settings.sentry.environment = "uat"
+        Settings.status.app_branch = "this-is/a.test-branch"
       end
 
-      it 'prefixes the submission queue name with the branch name' do
-        expect(call).to eq 'this-is-a-test-branch-submissions'
+      it "prefixes the submission queue name with the branch name" do
+        expect(call).to eq "this-is-a-test-branch-submissions"
       end
     end
 
-    context 'when the service is called anywhere other than UAT' do
+    context "when the service is called anywhere other than UAT" do
       before do
-        Settings.sentry.environment = 'test'
+        Settings.sentry.environment = "test"
       end
 
-      it 'sets the submission queue name to /submissions/' do
-        expect(call).to eq 'submissions'
+      it "sets the submission queue name to /submissions/" do
+        expect(call).to eq "submissions"
       end
     end
   end

--- a/spec/services/smoke_test_spec.rb
+++ b/spec/services/smoke_test_spec.rb
@@ -1,16 +1,16 @@
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe SmokeTest, :smoke_test do
   subject(:use_case) { described_class.call(:one) }
 
-  let(:expected_response) { File.read('./spec/fixtures/smoke_tests/use_case_one.json') }
+  let(:expected_response) { File.read("./spec/fixtures/smoke_tests/use_case_one.json") }
 
   before { WebMock.disable! }
 
   after { WebMock.enable! }
 
-  it 'returns the expected output' do
+  it "returns the expected output" do
     expect(use_case).to be true
-    expect(REDIS.get('smoke-test-one')).not_to be nil
+    expect(REDIS.get("smoke-test-one")).not_to be nil
   end
 end

--- a/spec/services/submission_service_spec.rb
+++ b/spec/services/submission_service_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe SubmissionService, vcr: { cassette_name: "use_case_one_success" }
         dob: "1992-07-22",
         start_date: "2020-08-01",
         end_date: "2020-10-01",
-        oauth_application: application
+        oauth_application: application,
       }
     end
 
@@ -56,7 +56,7 @@ RSpec.describe SubmissionService, vcr: { cassette_name: "use_case_one_success" }
           dob: "1992-07-22",
           start_date: "2020-08-01",
           end_date: "2020-10-01",
-          oauth_application: application
+          oauth_application: application,
         }
       end
 

--- a/spec/services/submission_service_spec.rb
+++ b/spec/services/submission_service_spec.rb
@@ -1,83 +1,83 @@
-require 'rails_helper'
+require "rails_helper"
 
-RSpec.describe SubmissionService, vcr: { cassette_name: 'use_case_one_success' } do
+RSpec.describe SubmissionService, vcr: { cassette_name: "use_case_one_success" } do
   include AuthorisedRequestHelper
 
-  describe '.call' do
+  describe ".call" do
     subject(:call) { described_class.call(submission) }
 
     let(:submission) { create :submission, data }
     let(:application) { dk_application }
     let(:data) do
       {
-        use_case: 'one',
-        first_name: 'Langley',
-        last_name: 'Yorke',
-        nino: 'MN212451D',
-        dob: '1992-07-22',
-        start_date: '2020-08-01',
-        end_date: '2020-10-01',
+        use_case: "one",
+        first_name: "Langley",
+        last_name: "Yorke",
+        nino: "MN212451D",
+        dob: "1992-07-22",
+        start_date: "2020-08-01",
+        end_date: "2020-10-01",
         oauth_application: application
       }
     end
 
     before do
       remove_request_stub(@hmrc_stub_requests)
-      allow(REDIS).to receive(:get).with('use_case_one_bearer_token').and_return('dummy_bearer_token')
+      allow(REDIS).to receive(:get).with("use_case_one_bearer_token").and_return("dummy_bearer_token")
     end
 
-    it 'adds a result attachment to the submission' do
+    it "adds a result attachment to the submission" do
       expect { call }.to change(ActiveStorage::Attachment, :count).by(1)
     end
 
-    it 'gives the submission result attachment the a filename' do
+    it "gives the submission result attachment the a filename" do
       call
       expect(submission.result.filename).to eq "#{submission.id}.json"
     end
 
-    it 'gives the submission result attachment a key' do
+    it "gives the submission result attachment a key" do
       call
       expect(submission.result.key).to eq "submission/result/#{submission.id}"
     end
 
-    it 'gives the submission result attachment a content type' do
+    it "gives the submission result attachment a content type" do
       call
-      expect(submission.result.content_type).to eq 'application/json'
+      expect(submission.result.content_type).to eq "application/json"
     end
 
-    context 'when the details are complete but not found on the calling service',
-            vcr: { cassette_name: 'use_case_one_fail' } do
+    context "when the details are complete but not found on the calling service",
+            vcr: { cassette_name: "use_case_one_fail" } do
       let(:data) do
         {
-          use_case: 'one',
-          first_name: 'this user',
-          last_name: 'does-not-exist',
-          nino: 'MN212451D',
-          dob: '1992-07-22',
-          start_date: '2020-08-01',
-          end_date: '2020-10-01',
+          use_case: "one",
+          first_name: "this user",
+          last_name: "does-not-exist",
+          nino: "MN212451D",
+          dob: "1992-07-22",
+          start_date: "2020-08-01",
+          end_date: "2020-10-01",
           oauth_application: application
         }
       end
 
-      it 'raises an error and records the error in the result' do
-        expect { call }.to raise_error Errors::CitizenDetailsMismatchError, 'User details not matched'
+      it "raises an error and records the error in the result" do
+        expect { call }.to raise_error Errors::CitizenDetailsMismatchError, "User details not matched"
         expect(submission.result.blob.download).to match(/submitted client details could not be found in HMRC service/)
       end
     end
 
-    context 'when the call fails with RestClient::InternalServerError' do
+    context "when the call fails with RestClient::InternalServerError" do
       before do
         allow(RestClient).to receive(:get).with(any_args).and_raise(RestClient::InternalServerError)
       end
 
-      it 'adds a result attachment detailing the error' do
+      it "adds a result attachment detailing the error" do
         call
         expect(submission.result.blob.download).to match(/returned INTERNAL_SERVER_ERROR/)
       end
     end
 
-    context 'when the call fails with RestClient::TooManyRequests' do
+    context "when the call fails with RestClient::TooManyRequests" do
       before do
         call_count = 0
         allow(RestClient).to receive(:get).with(any_args) do
@@ -90,17 +90,17 @@ RSpec.describe SubmissionService, vcr: { cassette_name: 'use_case_one_success' }
         end
       end
 
-      it 'logs that rate limiting occurred' do
+      it "logs that rate limiting occurred" do
         allow(Rails.logger).to receive(:info).at_least(:once)
         call
         expect(Rails.logger).to have_received(:info).with(/Rate limited while calling/).once
       end
 
-      it 'adds a result attachment to the submission' do
+      it "adds a result attachment to the submission" do
         expect { call }.to change(ActiveStorage::Attachment, :count).by(1)
       end
 
-      it 'does not add a result attachment detailing an error' do
+      it "does not add a result attachment detailing an error" do
         call
         expect(submission.result.blob.download).not_to match(/ERROR/)
       end

--- a/spec/services/use_case_spec.rb
+++ b/spec/services/use_case_spec.rb
@@ -1,36 +1,36 @@
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe UseCase do
   subject(:use_case) { described_class.new(:one) }
 
-  describe 'initializing' do
-    context 'when a valid bearer_token is available' do
+  describe "initializing" do
+    context "when a valid bearer_token is available" do
       before do
-        REDIS.set('use_case_one_bearer_token', 'fake_token_value')
+        REDIS.set("use_case_one_bearer_token", "fake_token_value")
         use_case
       end
 
-      it 'does not call the bearer_token generator' do
+      it "does not call the bearer_token generator" do
         expect(BearerToken).not_to receive(:call)
       end
     end
 
-    context 'when a valid bearer_token is not available' do
-      before { allow(BearerToken).to receive(:call).with('use_case_one').and_return('new_fake_token_value') }
+    context "when a valid bearer_token is not available" do
+      before { allow(BearerToken).to receive(:call).with("use_case_one").and_return("new_fake_token_value") }
 
-      it 'calls BearerToken and stores the value in redis' do
-        expect(REDIS.get('use_case_one_bearer_token')).to be nil
+      it "calls BearerToken and stores the value in redis" do
+        expect(REDIS.get("use_case_one_bearer_token")).to be nil
         use_case
-        expect(REDIS.get('use_case_one_bearer_token')).to eql 'new_fake_token_value'
+        expect(REDIS.get("use_case_one_bearer_token")).to eql "new_fake_token_value"
       end
     end
   end
 
-  describe '.host' do
+  describe ".host" do
     subject(:host) { use_case.host }
 
     before do
-      REDIS.set('use_case_one_bearer_token', 'fake_token_value')
+      REDIS.set("use_case_one_bearer_token", "fake_token_value")
       host
     end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -14,24 +14,24 @@
 #
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 
-require 'simplecov'
-require 'highline/import'
-require 'webmock'
-require 'webmock/rspec'
+require "simplecov"
+require "highline/import"
+require "webmock"
+require "webmock/rspec"
 WebMock.disable_net_connect!
-require 'redis'
-require 'mock_redis'
+require "redis"
+require "mock_redis"
 REDIS = MockRedis.new
-require 'rspec-sidekiq'
-require 'sidekiq/testing'
+require "rspec-sidekiq"
+require "sidekiq/testing"
 
 SimpleCov.minimum_coverage 100
-unless ENV['NOCOVERAGE']
+unless ENV["NOCOVERAGE"]
   SimpleCov.start do
-    add_filter 'spec/'
-    add_filter 'initializers/config.rb'
-    add_filter 'initializers/sidekiq_middleware.rb'
-    add_filter 'services/smoke_test.rb'
+    add_filter "spec/"
+    add_filter "initializers/config.rb"
+    add_filter "initializers/sidekiq_middleware.rb"
+    add_filter "services/smoke_test.rb"
   end
 
   SimpleCov.at_exit do
@@ -46,13 +46,13 @@ RSpec::Sidekiq.configure do |config|
   config.warn_when_jobs_not_processed_by_sidekiq = false # default => true
 end
 
-require 'vcr'
+require "vcr"
 
 VCR.configure do |vcr_config|
-  vcr_config.cassette_library_dir = 'spec/cassettes'
+  vcr_config.cassette_library_dir = "spec/cassettes"
   vcr_config.hook_into :webmock
   vcr_config.configure_rspec_metadata!
-  vcr_config.filter_sensitive_data('<SETTINGS__CREDENTIALS__HOST>') do
+  vcr_config.filter_sensitive_data("<SETTINGS__CREDENTIALS__HOST>") do
     Settings.credentials.host
   end
 end
@@ -62,7 +62,7 @@ RSpec.configure do |config|
 
   # set up default stub for the host, this can be overwritten in individual stubs if needed
   config.before do
-    @hmrc_stub_requests = stub_request(:post, %r{\A#{Settings.credentials.host}/.*\z}).to_return(status: 200, body: '')
+    @hmrc_stub_requests = stub_request(:post, %r{\A#{Settings.credentials.host}/.*\z}).to_return(status: 200, body: "")
   end
 
   config.before do

--- a/spec/support/authorised_request_helper.rb
+++ b/spec/support/authorised_request_helper.rb
@@ -8,6 +8,6 @@ module AuthorisedRequestHelper
   end
 
   def dk_application(scopes = %w[use_case_one use_case_two use_case_three use_case_four])
-    Doorkeeper::Application.create!(name: 'test', scopes:)
+    Doorkeeper::Application.create!(name: "test", scopes:)
   end
 end

--- a/spec/support/unauthorised_request.rb
+++ b/spec/support/unauthorised_request.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-RSpec.shared_examples 'an unauthorised request' do
-  it 'responds with a 401 status code' do
+RSpec.shared_examples "an unauthorised request" do
+  it "responds with a 401 status code" do
     get :index
     expect(response).to have_http_status(:unauthorized)
   end

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -1,12 +1,12 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.configure do |config|
   # Specify a root folder where Swagger JSON files are generated
   # NOTE: If you're using the rswag-api to serve API descriptions, you'll need
   # to ensure that it's configured to serve Swagger from the same folder
-  config.swagger_root = Rails.root.join('swagger').to_s
+  config.swagger_root = Rails.root.join("swagger").to_s
 
   # Define one or more Swagger documents and provide global metadata for each one
   # When you run the 'rswag:specs:swaggerize' rake task, the complete Swagger will
@@ -15,12 +15,12 @@ RSpec.configure do |config|
   # document below. You can override this behavior by adding a swagger_doc tag to the
   # the root example_group in your specs, e.g. describe '...', swagger_doc: 'v2/swagger.json'
   config.swagger_docs = {
-    'v1/swagger.yaml' => {
-      openapi: '3.0.1',
+    "v1/swagger.yaml" => {
+      openapi: "3.0.1",
       info: {
-        title: 'LAA HMRC Interface Service',
-        description: 'This Service facilitates the HMRC API access for the LAA Use Cases',
-        version: 'v1'
+        title: "LAA HMRC Interface Service",
+        description: "This Service facilitates the HMRC API access for the LAA Use Cases",
+        version: "v1"
       },
       paths: {},
       components: {
@@ -28,10 +28,10 @@ RSpec.configure do |config|
           oAuth: {
             in: :header,
             type: :oauth2,
-            description: 'OAuth2 client credentials flow',
+            description: "OAuth2 client credentials flow",
             flows: {
               clientCredentials: {
-                tokenUrl: '/oauth/token'
+                tokenUrl: "/oauth/token"
               }
             }
           }

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -20,7 +20,7 @@ RSpec.configure do |config|
       info: {
         title: "LAA HMRC Interface Service",
         description: "This Service facilitates the HMRC API access for the LAA Use Cases",
-        version: "v1"
+        version: "v1",
       },
       paths: {},
       components: {
@@ -31,13 +31,13 @@ RSpec.configure do |config|
             description: "OAuth2 client credentials flow",
             flows: {
               clientCredentials: {
-                tokenUrl: "/oauth/token"
-              }
-            }
-          }
-        }
-      }
-    }
+                tokenUrl: "/oauth/token",
+              },
+            },
+          },
+        },
+      },
+    },
   }
 
   # Specify the format of the output Swagger file when running 'rswag:specs:swaggerize'.

--- a/spec/workers/submission_process_worker_spec.rb
+++ b/spec/workers/submission_process_worker_spec.rb
@@ -1,4 +1,4 @@
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe SubmissionProcessWorker do
   include AuthorisedRequestHelper
@@ -14,55 +14,55 @@ RSpec.describe SubmissionProcessWorker do
     allow(SubmissionService).to receive(:call).and_return(true)
   end
 
-  describe '.perform' do
-    it 'calls SubmissionService' do
+  describe ".perform" do
+    it "calls SubmissionService" do
       expect(SubmissionService).to receive(:call)
       submission_process_worker
     end
 
-    it 'updates the submission status' do
+    it "updates the submission status" do
       submission_process_worker
-      expect(submission.status).to eq('completed')
+      expect(submission.status).to eq("completed")
     end
 
-    context 'when submission errors' do
-      context 'with a client details mismatch error' do
+    context "when submission errors" do
+      context "with a client details mismatch error" do
         before do
           allow(SubmissionService).to receive(:call).and_raise(Errors::CitizenDetailsMismatchError)
           worker.retry_count = 0
         end
 
-        it 'updates the submission status amd records the error ' do
+        it "updates the submission status amd records the error " do
           submission_process_worker
-          expect(submission.status).to eq('failed')
+          expect(submission.status).to eq("failed")
         end
       end
 
-      context 'with a generic error' do
+      context "with a generic error" do
         before do
-          allow(SubmissionService).to receive(:call).and_raise(StandardError, 'A problem occurred')
+          allow(SubmissionService).to receive(:call).and_raise(StandardError, "A problem occurred")
         end
 
-        context 'before the final retry' do
+        context "before the final retry" do
           before { worker.retry_count = 2 }
 
-          it 'raises a not tracked error and leaves the status' do
+          it "raises a not tracked error and leaves the status" do
             expect { submission_process_worker }.to raise_error Errors::SentryIgnoresThisSidekiqFailError
-            expect(submission.status).to eq 'processing'
+            expect(submission.status).to eq "processing"
           end
         end
 
-        context 'when the retry is at the max retries' do
+        context "when the retry is at the max retries" do
           let(:expected_message) { "Moving SubmissionProcessWorker# to dead set, it failed with: /An error occured\n" }
 
           before { worker.retry_count = 3 }
 
-          it 'updates the submission status' do
-            expect { submission_process_worker }.to raise_error StandardError, 'A problem occurred'
-            expect(submission.status).to eq('failed')
+          it "updates the submission status" do
+            expect { submission_process_worker }.to raise_error StandardError, "A problem occurred"
+            expect(submission.status).to eq("failed")
           end
 
-          it 'notifies sentry of the deadset addition' do
+          it "notifies sentry of the deadset addition" do
             described_class.within_sidekiq_retries_exhausted_block do
               expect(Sentry).to receive(:capture_message).with(expected_message)
             end


### PR DESCRIPTION
## What

Address final, large scale rubocop todos
* Style/StringLiterals (autocorrected)
* Style/TrailingCommaInHashLiteral (autocorrected)

There remain three infractions that should remain in todo for now:
* RSpec/ContextWording - excludes a single file while a PR remains open on rubocop-govuk
* RSpec/InstanceVariable - remains because the pattern used matches that suggested by WebMocks
* RSpec/VariableName - the `let(:Authorization)` header block fails if it is downcased, but the cop fails if it is moved from `.rubocop_todo.yml` -> .`rubocop.yml`!

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
- You should have run `NOCOVERAGE=true rake rswag` to ensure the swagger docs are up-to-date
