### PR TITLE
Fix GOV.UK Rubocop offences

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -6,13 +6,6 @@
 # Note that changes in the inspected code, or installation of new
 # versions of RuboCop, may require this file to be generated again.
 
-# Offense count: 2
-# Configuration parameters: AssignmentOnly.
-RSpec/InstanceVariable:
-  Exclude:
-    - 'spec/services/hmrc/sandbox/create_test_data_spec.rb'
-    - 'spec/services/submission_service_spec.rb'
-
 # Offense count: 3
 # Configuration parameters: IgnoredPatterns.
 # SupportedStyles: snake_case, camelCase

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -6,13 +6,6 @@
 # Note that changes in the inspected code, or installation of new
 # versions of RuboCop, may require this file to be generated again.
 
-# Offense count: 1
-# Configuration parameters: Prefixes.
-# Prefixes: when, with, without
-RSpec/ContextWording:
-  Exclude:
-    - 'spec/workers/submission_process_worker_spec.rb'
-
 # Offense count: 2
 # Configuration parameters: AssignmentOnly.
 RSpec/InstanceVariable:

--- a/spec/services/hmrc/sandbox/create_test_data_spec.rb
+++ b/spec/services/hmrc/sandbox/create_test_data_spec.rb
@@ -6,7 +6,7 @@ describe HMRC::Sandbox::CreateTestData do
   let(:type) { :paye }
 
   before do
-    remove_request_stub(@hmrc_stub_requests)
+    remove_request_stub(hmrc_stub_requests)
     allow(REDIS).to receive(:get).with("use_case_one_bearer_token").and_return("dummy_bearer_token")
     stub_request(:post, /\A#{Settings.credentials.host}.*\z/).to_return(status: 201, body: "", headers: {})
   end

--- a/spec/services/submission_service_spec.rb
+++ b/spec/services/submission_service_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe SubmissionService, vcr: { cassette_name: "use_case_one_success" }
     end
 
     before do
-      remove_request_stub(@hmrc_stub_requests)
+      remove_request_stub(hmrc_stub_requests)
       allow(REDIS).to receive(:get).with("use_case_one_bearer_token").and_return("dummy_bearer_token")
     end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -62,7 +62,9 @@ RSpec.configure do |config|
 
   # set up default stub for the host, this can be overwritten in individual stubs if needed
   config.before do
-    @hmrc_stub_requests = stub_request(:post, %r{\A#{Settings.credentials.host}/.*\z}).to_return(status: 200, body: "")
+    def hmrc_stub_requests
+      stub_request(:post, %r{\A#{Settings.credentials.host}/.*\z}).to_return(status: 200, body: "")
+    end
   end
 
   config.before do

--- a/spec/workers/submission_process_worker_spec.rb
+++ b/spec/workers/submission_process_worker_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe SubmissionProcessWorker do
           allow(SubmissionService).to receive(:call).and_raise(StandardError, "A problem occurred")
         end
 
-        context "before the final retry" do
+        context "when before the final retry" do
           before { worker.retry_count = 2 }
 
           it "raises a not tracked error and leaves the status" do


### PR DESCRIPTION
## What

Fix GOV.UK Rubocop offences:
  - RSpec/InstanceVariable
  - RSpec/ContextWording

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
- You should have run `NOCOVERAGE=true rake rswag` to ensure the swagger docs are up-to-date
