### PR TITLE
AP-2860 UAT deployments for branches with caps

### DIFF
--- a/bin/uat_deploy
+++ b/bin/uat_deploy
@@ -2,7 +2,7 @@
 
 deploy() {
   IMG_REPO="$ECR_ENDPOINT/laa-apply-for-legal-aid/laa-hmrc-interface-uat-ecr"
-  RELEASE_NAME=$(echo $CIRCLE_BRANCH | sed 's:^\w*\/::' | tr -s ' _/[]().' '-' | cut -c1-30 | sed 's/-$//')
+  RELEASE_NAME=$(echo $CIRCLE_BRANCH | tr '[:upper:]' '[:lower:]' | sed 's:^\w*\/::' | tr -s ' _/[]().' '-' | cut -c1-30 | sed 's/-$//')
   RELEASE_HOST="$RELEASE_NAME-laa-hmrc-interface-uat.cloud-platform.service.justice.gov.uk"
   LEGACY_RELEASE_HOST="$RELEASE_NAME-laa-hmrc-interface-uat.apps.live-1.cloud-platform.service.justice.gov.uk"
   BRANCH_NAME=$(echo $CIRCLE_BRANCH | tr -s ' _/[]().' '-')


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-2860)

At present UAT deployments fail if the github branch contains a capital
letter. This fixes the deploy script so that all branch names are
downcased.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
- You should have run `NOCOVERAGE=true rake rswag` to ensure the swagger docs are up-to-date
