### PR TITLE
Remove validates timeliness gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,7 +24,6 @@ gem "sentry-rails"
 gem "sentry-ruby"
 gem "sidekiq"
 gem "timeliness-i18n"
-gem "validates_timeliness", "~> 6.0.0.beta2"
 
 group :development, :test do
   gem "byebug"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -401,9 +401,6 @@ GEM
       unf_ext
     unf_ext (0.0.8)
     unicode-display_width (2.1.0)
-    validates_timeliness (6.0.0.beta2)
-      activemodel (>= 6.0.0, < 7)
-      timeliness (>= 0.3.10, < 1)
     vcr (6.0.0)
     webmock (3.14.0)
       addressable (>= 2.8.0)
@@ -463,7 +460,6 @@ DEPENDENCIES
   spring
   timeliness-i18n
   tzinfo-data
-  validates_timeliness (~> 6.0.0.beta2)
   vcr
   webmock
 

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -12,9 +12,10 @@ class Submission < ApplicationRecord
   validates :first_name, presence: true
   validates :last_name, presence: true
   validate :validate_nino
-  validates_date :dob, on_or_before: :today
-  validates_date :start_date, on_or_before: :today
-  validates_date :end_date, on_or_before: :today, after: :start_date
+  validates :dob, date: { not_in_the_future: true }
+  validates :start_date, date: { not_in_the_future: true }
+  validates :end_date, date: { not_in_the_future: true }
+  validate :end_date_after_start_date
 
   def as_json(*)
     super.except("id", "status", "created_at", "updated_at", "oauth_application_id")
@@ -31,5 +32,14 @@ class Submission < ApplicationRecord
     return if NINO_REGEXP.match?(nino)
 
     errors.add(:nino, "is not valid")
+  end
+
+private
+
+  def end_date_after_start_date
+    return if end_date.blank? || start_date.blank?
+
+    errors.add(:start_date, :invalid_timeline) if end_date < start_date
+    errors.add(:end_date, :invalid_timeline) if end_date < start_date
   end
 end

--- a/app/validators/date_validator.rb
+++ b/app/validators/date_validator.rb
@@ -1,0 +1,38 @@
+class DateValidator < ActiveModel::EachValidator
+  DEFAULT_FORMAT = "%Y-%m-%d".freeze
+  DEFAULT_EARLIEST_DATE = "1900-01-01".freeze
+
+  def validate_each(record, attribute, value)
+    value = parse_date(value, options[:format]) if value.is_a?(String)
+    return unless valid_date(record, attribute, value)
+
+    validate_not_in_future(record, attribute, value)
+  end
+
+private
+
+  def parse_date(date_str, format)
+    format ||= DEFAULT_FORMAT
+    Time.strptime(date_str, format).in_time_zone
+  rescue StandardError
+    nil
+  end
+
+  def valid_date(record, attribute, value)
+    message = options[:message] || :date_not_valid
+    unless value.is_a?(Date) || value.is_a?(ActiveSupport::TimeWithZone)
+      record.errors.add(attribute, message)
+      return false
+    end
+    true
+  end
+
+  def validate_not_in_future(record, attribute, value)
+    required = options[:not_in_the_future]
+    return if required.blank?
+
+    message = required[:message] if required.is_a?(Hash)
+    message ||= :date_is_in_the_future
+    record.errors.add(attribute, message) if value > Date.current
+  end
+end

--- a/config/initializers/validates_timeliness.rb
+++ b/config/initializers/validates_timeliness.rb
@@ -1,3 +1,0 @@
-ValidatesTimeliness.setup do |config|
-  config.extend_orms = [:active_record]
-end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,33 +1,17 @@
-# Files in the config/locales directory are used for internationalization
-# and are automatically loaded by Rails. If you want to use locales other
-# than English, add the necessary files in this directory.
-#
-# To use the locales, use `I18n.t`:
-#
-#     I18n.t 'hello'
-#
-# In views, this is aliased to just `t`:
-#
-#     <%= t('hello') %>
-#
-# To use a different locale, set it with `I18n.locale`:
-#
-#     I18n.locale = :es
-#
-# This would use the information in config/locales/es.yml.
-#
-# The following keys must be escaped otherwise they will not be retrieved by
-# the default I18n backend:
-#
-# true, false, on, off, yes, no
-#
-# Instead, surround them with single quotes.
-#
-# en:
-#   'true': 'foo'
-#
-# To learn more, please read the Rails Internationalization guide
-# available at https://guides.rubyonrails.org/i18n.html.
-
 en:
-  hello: "Hello world"
+  activerecord:
+    errors:
+      models:
+        submission:
+          attributes:
+            dob:
+              date_not_valid: is not a valid date
+              date_is_in_the_future: is not a valid date
+            start_date:
+              date_not_valid: is not a valid date
+              date_is_in_the_future: is not a valid date
+              invalid_timeline: is not a valid date
+            end_date:
+              date_not_valid: is not a valid date
+              date_is_in_the_future: is not a valid date
+              invalid_timeline: is not a valid date


### PR DESCRIPTION
## What

The validates_timeliness gem has been blocking the Rails 7 update for too long
This PR replaces the three validations that used it and replaces it with code taken from Apply that does a similar job
Then it removes the gem and it's config 

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
- You should have run `NOCOVERAGE=true rake rswag` to ensure the swagger docs are up-to-date
