### PR TITLE
[AP-3184] add delete uat release github action

### DIFF
--- a/.github/workflows/delete-uat-release.yml
+++ b/.github/workflows/delete-uat-release.yml
@@ -1,0 +1,23 @@
+name: Delete UAT release
+
+on:
+  pull_request:
+    types:
+      - closed
+
+jobs:
+  delete_uat_job:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Delete UAT release action
+        id: delete_uat
+        uses: ministryofjustice/laa-civil-apply-delete-uat-release@v1.0.0
+        with:
+          k8s_cluster: ${{ secrets.K8S_GHA_UAT_CLUSTER_NAME }}
+          k8s_cluster_cert: ${{ secrets.K8S_GHA_UAT_CLUSTER_CERT }}
+          k8s_namespace: ${{ secrets.K8S_GHA_UAT_NAMESPACE }}
+          k8s_token: ${{ secrets.K8S_GHA_UAT_TOKEN }}
+      - name: Result
+        shell: bash
+        run: echo ${{ steps.delete_uat.outputs.delete-message }}

--- a/.github/workflows/delete-uat-release.yml
+++ b/.github/workflows/delete-uat-release.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Delete UAT release action
+      - name: Delete UAT release
         id: delete_uat
         uses: ministryofjustice/laa-civil-apply-delete-uat-release@v1.0.0
         with:
@@ -18,6 +18,15 @@ jobs:
           k8s_cluster_cert: ${{ secrets.K8S_GHA_UAT_CLUSTER_CERT }}
           k8s_namespace: ${{ secrets.K8S_GHA_UAT_NAMESPACE }}
           k8s_token: ${{ secrets.K8S_GHA_UAT_TOKEN }}
+
+      - name: Delete UAT RDS database
+        shell: bash
+        id: delete_uat_db
+        run: |
+          bin/uat_drop_db ${{ steps.delete_uat.outputs.release-name }}
+
       - name: Result
         shell: bash
-        run: echo ${{ steps.delete_uat.outputs.delete-message }}
+        run: |
+          echo ${{ steps.delete_uat.outputs.delete-message }}
+          echo ${{ steps.delete_uat_db.outputs.drop-commmand-result }}

--- a/bin/uat_drop_db
+++ b/bin/uat_drop_db
@@ -1,0 +1,99 @@
+#!/bin/bash
+
+function _uat_drop_db() {
+  usage="uat_drop_db -- drop an rds instance with same name as that specified
+  Usage: bin/uat_drop_db <uat-branch-name>
+  Example:
+    # drop postgres database connected to the UAT RDS instance with a name matching "my-uat-branch-name"
+    bin/uat_drop_db my-uat-branch-name
+    "
+
+  # exit when any command fails, keep track of the last for output
+  # https://intoli.com/blog/exit-on-errors-in-bash-scripts/
+  set -e
+  trap 'last_command=$current_command; current_command=$BASH_COMMAND' DEBUG
+  trap 'echo "\"${last_command}\" command completed with exit code $?."' EXIT
+
+  current_namespace=$(kubectl config view --minify --output 'jsonpath={..namespace}'; echo)
+  if [[ ! $current_namespace =~ -uat$ ]]
+  then
+    echo "namespace must be UAT!"
+    return 1
+  fi
+
+  if [[ $# -ne 1 ]]
+  then
+    echo "$usage"
+    return 0
+  else
+    UAT_RELEASE=$1
+  fi
+
+  echo 'Retrieve RDS credentials'
+  DB_HOST=$(kubectl -n "${K8S_NAMESPACE}" get secret rds-instance-output -o jsonpath="{.data.rds_instance_address}" | base64 --decode)
+  DB_NAME=$(kubectl -n "${K8S_NAMESPACE}" get secret rds-instance-output -o jsonpath="{.data.database_name}" | base64 --decode)
+  DB_USER=$(kubectl -n "${K8S_NAMESPACE}" get secret rds-instance-output -o jsonpath="{.data.database_username}" | base64 --decode)
+  DB_PWD=$(kubectl -n "${K8S_NAMESPACE}" get secret rds-instance-output -o jsonpath="{.data.database_password}" | base64 --decode)
+
+  echo "Ensuring port-forward-pod exists"
+  FORWADING_POD=$(kubectl -n "${K8S_NAMESPACE}" get pods | grep -m4 port-forward-pod | head -n1 | cut -d' ' -f 1)
+  if [ -z "$FORWADING_POD" ]; then
+    echo 'Creating new port-forward-pod'
+    kubectl -n "${K8S_NAMESPACE}" run port-forward-pod \
+      --image=ministryofjustice/port-forward \
+      --port=5432 \
+      --env="REMOTE_HOST=${DB_HOST}" \
+      --env="LOCAL_PORT=5432" \
+      --env="REMOTE_PORT=5432"
+  fi
+
+  echo 'Waiting for port-forward-pod to be ready...'
+  kubectl -n "${K8S_NAMESPACE}" wait --for=condition=ready pod port-forward-pod --timeout=32s
+
+  echo 'Starting port-forwarding as a background job'
+  kubectl -n "${K8S_NAMESPACE}" port-forward port-forward-pod 5433:5432 &
+
+  # Check App/web pods deleted, as open connections to DB can cause problems
+  APP_POD=$(kubectl -n "${K8S_NAMESPACE}" get pods | grep -m4 "${UAT_RELEASE}" | head -n1 | cut -d' ' -f 1)
+  if [ -z "$APP_POD" ]; then
+    echo "Ensuring ${UAT_RELEASE} pod has terminated"
+    kubectl -n "${K8S_NAMESPACE}" wait --for=delete pod/"${UAT_RELEASE}" --timeout=32s
+  fi
+
+  echo 'Sending RDS delete command...'
+  for i in {1..3}; do
+    sleep 3
+    echo "Attempt: $i"
+    GET_QUERY="SELECT datname FROM pg_database WHERE datname ILIKE '${UAT_RELEASE}%'"
+    DATABASE_TO_DROP=$(psql postgres://"${DB_USER}":"${DB_PWD}"@localhost:5433/"${DB_NAME}" -qtc "${GET_QUERY};" | xargs) # xargs trims the spaces around the psql output of names
+    echo "Found ${DATABASE_TO_DROP} to be dropped"
+
+    ALTER_CONN_LIMIT="ALTER DATABASE \"${DATABASE_TO_DROP}\" CONNECTION LIMIT 0;"
+    ALTER_CONNECTIONS_OUTPUT=$(psql postgres://"${DB_USER}":"${DB_PWD}"@localhost:5433/"${DB_NAME}" -qtc "${ALTER_CONN_LIMIT};")
+
+    CLOSE_CONN_QUERY="SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = '${DATABASE_TO_DROP}'"
+    CLOSE_CONNECTIONS_OUTPUT=$(psql postgres://"${DB_USER}":"${DB_PWD}"@localhost:5433/"${DB_NAME}" -qtc "${CLOSE_CONN_QUERY};" | xargs)
+
+    DROP_DATABASE_CMD="DROP DATABASE \"${DATABASE_TO_DROP}\";"
+    DROP_DATABASE_OUTPUT=$(psql postgres://"${DB_USER}":"${DB_PWD}"@localhost:5433/"${DB_NAME}" -c "${DROP_DATABASE_CMD};")
+
+    DROPPED=$(echo "$DROP_DATABASE_OUTPUT" | grep -c 'DROP DATABASE')
+    if [[ $DROPPED == 1 ]]
+    then
+      DROP_DATABASE_RESULT="Dropped database ${DATABASE_TO_DROP}!"
+    else
+      DROP_DATABASE_RESULT="UAT database, ${DATABASE_TO_DROP} not dropped!"
+    fi
+
+    echo "##[set-output name=drop-commmand-result;]$(echo "${DROP_DATABASE_RESULT}")"
+    [[ $DROPPED == 1 ]] && break
+  done
+
+  echo 'Killing port-forwarding background job'
+  kill $!
+
+  echo 'Deleting port-forwarding pod'
+  kubectl -n "${K8S_NAMESPACE}" delete pod port-forward-pod --wait=false
+}
+
+_uat_drop_db $@


### PR DESCRIPTION
- Add github action workflow to call shared action
- Add separate script to call for deleting DBs


## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-3184)

In line with other apply service repos this uses a github action
to delete UAT releases/deployments.

An additional step extends this behaviour to also delete RDS database
instances with names based on the branch name. This is because unlike
the other apply service repos that spin up a dedicated postgres
database pod the HMRC Interface uses a single UAT RDS instance but
creates and connects to a dedicated RDS instance database with a name
matching the branch.


## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
- You should have run `NOCOVERAGE=true rake rswag` to ensure the swagger docs are up-to-date
