### PR TITLE
Make UAT drop db query more specific

### DIFF
--- a/bin/uat_drop_db
+++ b/bin/uat_drop_db
@@ -82,7 +82,12 @@ function _uat_drop_db() {
     echo "Attempt: $i"
     GET_QUERY="SELECT datname FROM pg_database WHERE datname = '${UAT_RELEASE}'"
     DATABASE_TO_DROP=$(psql postgres://"${DB_USER}":"${DB_PWD}"@localhost:5433/"${DB_NAME}" -qtc "${GET_QUERY};" | xargs) # xargs trims the spaces around the psql output of names
-    [[ -z "${DATABASE_TO_DROP}" ]] && echo "DATABASE NOT FOUND \"${UAT_RELEASE}\"!" && break
+    if [[ -z "${DATABASE_TO_DROP}" ]]; then
+      echo "DATABASE NOT FOUND \"${UAT_RELEASE}\"!"
+      break
+    else
+      echo "DATABASE FOUND \"${DATABASE_TO_DROP}\"!"
+    fi
 
     ALTER_CONN_LIMIT="ALTER DATABASE \"${DATABASE_TO_DROP}\" CONNECTION LIMIT 0;"
     ALTER_CONNECTIONS_OUTPUT=$(psql postgres://"${DB_USER}":"${DB_PWD}"@localhost:5433/"${DB_NAME}" -qtc "${ALTER_CONN_LIMIT};")

--- a/bin/uat_drop_db
+++ b/bin/uat_drop_db
@@ -80,7 +80,7 @@ function _uat_drop_db() {
   for i in {1..3}; do
     sleep 3
     echo "Attempt: $i"
-    GET_QUERY="SELECT datname FROM pg_database WHERE datname ILIKE '${UAT_RELEASE}%'"
+    GET_QUERY="SELECT datname FROM pg_database WHERE datname = '${UAT_RELEASE}'"
     DATABASE_TO_DROP=$(psql postgres://"${DB_USER}":"${DB_PWD}"@localhost:5433/"${DB_NAME}" -qtc "${GET_QUERY};" | xargs) # xargs trims the spaces around the psql output of names
     [[ -z "${DATABASE_TO_DROP}" ]] && echo "DATABASE NOT FOUND \"${UAT_RELEASE}\"!" && break
 


### PR DESCRIPTION
## What
[Link to story](https://dsdmoj.atlassian.net/browse/AP-3184)

Make the query to identify the DB to drop more specific as
we are now using a specific release name, plus if more than
one DB name is returned the script fails anyway.

Also, add output to confirm DB found

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
- You should have run `NOCOVERAGE=true rake rswag` to ensure the swagger docs are up-to-date
