### PR TITLE
Fix: Lock Doorkeeper below 5.6

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ ruby "3.1.2"
 gem "aws-sdk-s3", require: false
 gem "bootsnap", ">= 1.4.4", require: false
 gem "config"
-gem "doorkeeper", "~> 5.5.4"
+gem "doorkeeper", "~> 5.5.4", "< 5.6"
 gem "dotenv-rails"
 gem "net-imap"
 gem "net-pop"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -420,7 +420,7 @@ DEPENDENCIES
   bootsnap (>= 1.4.4)
   byebug
   config
-  doorkeeper (~> 5.5.4)
+  doorkeeper (~> 5.5.4, < 5.6)
   dotenv-rails
   factory_bot_rails (>= 6.2.0)
   faker (>= 1.9.1)


### PR DESCRIPTION
## What

The pessimistic operator only locked us below v6, dependabot still wanted to apply the v5.6.0 update

This locks it below the known breaking change

See the [Doorkeeper issue](https://github.com/doorkeeper-gem/doorkeeper/issues/1588) for reasons

Two options for resolution
* a doorkeeper fix 
* we refactor the authentication to require scopes via the rswag login and API submission

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
- You should have run `NOCOVERAGE=true rake rswag` to ensure the swagger docs are up-to-date
