### PR TITLE
Patch critical zlib vulnerability

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ RUN set -ex
 RUN apk --no-cache add --virtual build-dependencies \
                     build-base \
                     postgresql-dev \
+                    "zlib>1.2.12-r2" \
 && apk --no-cache add postgresql-client
 
 RUN mkdir /app


### PR DESCRIPTION
## What
Patch critical zlib vulnerability

[Warning](https://github.com/ministryofjustice/laa-hmrc-interface-service-api/security/code-scanning/13) raised by snyk code scanning.

Updates to r3 from r0
```
# before
zlib-dev-1.2.12-r0 x86_64 {zlib} (Zlib) [installed]
zlib-1.2.12-r0 x86_64 {zlib} (Zlib) [installed]
# after
zlib-dev-1.2.12-r3 x86_64 {zlib} (Zlib) [installed]
zlib-1.2.12-r3 x86_64 {zlib} (Zlib) [installed]
```

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
- You should have run `NOCOVERAGE=true rake rswag` to ensure the swagger docs are up-to-date
