### PR TITLE
Bump alpine 3.14 to 3.16 to patch vulnerability

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:3.1.2-alpine3.14
+FROM ruby:3.1.2-alpine3.16
 
 MAINTAINER Apply for legal aid team
 


### PR DESCRIPTION
## What
Bump alpine 3.14 to 3.16

Another/different/cleaner attempt to patch zlib cirtical vulnerability.

Updates r3 from r0
```
zlib-dev-1.2.12-r3 x86_64 {zlib} (Zlib) [installed]
zlib-1.2.12-r3 x86_64 {zlib} (Zlib) [installed]
```

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
- You should have run `NOCOVERAGE=true rake rswag` to ensure the swagger docs are up-to-date
