### PR TITLE
Update setup instructions

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -401,10 +401,7 @@ GEM
     zeitwerk (2.6.6)
 
 PLATFORMS
-  x86_64-darwin-18
-  x86_64-darwin-19
-  x86_64-darwin-20
-  x86_64-linux
+  ruby
 
 DEPENDENCIES
   aws-sdk-s3

--- a/README.md
+++ b/README.md
@@ -7,13 +7,28 @@ This Service facilitates the HMRC API access for the LAA Use Cases
 
 ## Development
 ### Dependencies
-* Ruby 3
-* Rails 6.1.x API
+* Ruby 3.1.x
+* Rails 7.0.x API
 
 ### System Dependencies
 * postgres
 * redis
-* sidekiq
+
+### Setup
+1. Retrieve the `GIT_CRYPT_KEY` from LastPass
+1. Unlock encrypted secrets
+
+```sh
+git-crypt unlock <path-to-git-crypt-key>
+```
+
+1. Copy the `.env` file from LastPass
+
+1. Run the setup binstub
+
+```sh
+bin/setup
+```
 
 ### Further reading
 * Developer looking to use the API? - [Click here](docs/development.md)

--- a/bin/setup
+++ b/bin/setup
@@ -1,5 +1,5 @@
 #!/usr/bin/env ruby
-# require 'fileutils'
+require "fileutils"
 
 # path to your application root.
 APP_ROOT = File.expand_path('..', __dir__)

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,8 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_09_22_134149) do
-
+ActiveRecord::Schema[7.0].define(version: 2021_09_22_134149) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -81,8 +80,8 @@ ActiveRecord::Schema.define(version: 2021_09_22_134149) do
     t.text "redirect_uri"
     t.boolean "confidential", default: true, null: false
     t.string "scopes", default: "", null: false
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["uid"], name: "index_oauth_applications_on_uid", unique: true
   end
 
@@ -95,8 +94,8 @@ ActiveRecord::Schema.define(version: 2021_09_22_134149) do
     t.string "start_date"
     t.string "end_date"
     t.string "status"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.uuid "oauth_application_id"
     t.index ["oauth_application_id"], name: "index_submissions_on_oauth_application_id"
   end


### PR DESCRIPTION
Before, `bin/setup` could not be run successfully immmediately after cloning.

There were several intermediate steps that needed to be taken before the setup script could be run, and tests would pass locally.

This updates the setup instructions and related files to reflect that.

- Include intermediate steps in `README.md`
- Update lockfile Platform to be less specific
- Uncomment `require` in `bin/setup`
- Commit changes to `db/schema.rb` to reflect Rails 7 defaults
