### PR TITLE
Only eager load Ruby code when running tests in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,21 +16,21 @@ executors:
     docker:
       - image: cimg/ruby:3.1.3-node
         environment:
-          - RAILS_ENV=test
-          - TZ: "Europe/London"
+          RAILS_ENV: test
+          TZ: "Europe/London"
   test-executor:
     docker:
       - image: cimg/ruby:3.1.3-node
         environment:
-          - RAILS_ENV=test
-          - PGHOST=localhost
-          - PGUSER=user
-          - TZ: "Europe/London"
+          RAILS_ENV: test
+          PGHOST: localhost
+          PGUSER: user
+          TZ: "Europe/London"
       - image: cimg/redis:5.0
       - image: cimg/postgres:10.18
         environment:
-          - POSTGRES_USER=user
-          - POSTGRES_DB=laa_hmrc_interface_service_api_test
+          POSTGRES_USER: user
+          POSTGRES_DB: laa_hmrc_interface_service_api_test
 references:
   build_docker_image: &build_docker_image
     run:

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -11,10 +11,10 @@ Rails.application.configure do
   config.cache_classes = false
   config.action_view.cache_template_loading = true
 
-  # Do not eager load code on boot. This avoids loading your whole application
-  # just for the purpose of running a single test. If you are using a tool that
-  # preloads Rails for running tests, you may have to set it to true.
-  config.eager_load = false
+  # Eager loading loads your whole application. When running a single test locally,
+  # this probably isn't necessary. It's a good idea to do in a continuous integration
+  # system, or in some way before deploying your code.
+  config.eager_load = ENV["CI"].present?
 
   # Configure public file server for tests with Cache-Control for performance.
   config.public_file_server.enabled = true

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -32,6 +32,7 @@ unless ENV["NOCOVERAGE"]
     add_filter "initializers/config.rb"
     add_filter "initializers/sidekiq_middleware.rb"
     add_filter "services/smoke_test.rb"
+    add_filter "services/test_submission.rb"
   end
 
   SimpleCov.at_exit do


### PR DESCRIPTION
Before, the code was eager loaded every time a test was run.

When you're running a single test, this doesn't make much sense.

This updates the test configuration to eager load only when the `CI` environment
variable is set (i.e default Rails behaviour).