### PR TITLE
Fix: unescaped url warning

### DIFF
--- a/spec/requests/api/v1/submissions_swagger_spec.rb
+++ b/spec/requests/api/v1/submissions_swagger_spec.rb
@@ -69,7 +69,9 @@ RSpec.describe "GET submission", type: :request, swagger_doc: "v1/swagger.yaml" 
             expect(response.media_type).to eq("application/json")
             expect(response.body).to match(/id/)
             expect(response.body).to match(/_links/)
-            expect(JSON.parse(response.body)["_links"].first["href"]).to match(%r{http://www.example.com/api/v1/submission/result/})
+            json_response = JSON.parse(response.body)
+
+            expect(json_response["_links"].first["href"]).to eq "http://www.example.com/api/v1/submission/result/#{json_response['id']}"
           end
         end
 


### PR DESCRIPTION


## What

This replaces a regex match that did not include the id with a string match that includes the id returned in the JSON block.

This ensures the URL matches the ID as well as addresses the URL warning raised by code climate

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
- You should have run `NOCOVERAGE=true rake rswag` to ensure the swagger docs are up-to-date
