### PR TITLE
Fix reference to output from shared action

### DIFF
--- a/.github/workflows/delete-uat-release.yml
+++ b/.github/workflows/delete-uat-release.yml
@@ -27,7 +27,7 @@ jobs:
         shell: bash
         id: delete_uat_db
         run: |
-          bin/uat_drop_db ${{ steps.delete_uat.outputs.release-name }}
+          bin/uat_drop_db ${{ steps.delete_uat.outputs.release_name }}
 
       - name: Result
         shell: bash


### PR DESCRIPTION
## What
Fix UAT DB delete

The output `release-name` became `release_name` in version 1.0.1
of the shared action.


## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
- You should have run `NOCOVERAGE=true rake rswag` to ensure the swagger docs are up-to-date
