### PR TITLE
Replace deprecated `set-output` command

### DIFF
--- a/bin/uat_drop_db
+++ b/bin/uat_drop_db
@@ -106,7 +106,7 @@ function _uat_drop_db() {
       DROP_DATABASE_RESULT="UAT database, ${DATABASE_TO_DROP} not dropped!"
     fi
 
-    echo "##[set-output name=drop-commmand-result;]$(echo "${DROP_DATABASE_RESULT}")"
+    echo "drop-commmand-result=${DROP_DATABASE_RESULT}" >> $GITHUB_OUTPUT
     [[ $DROPPED == 1 ]] && break
   done
 


### PR DESCRIPTION
Script makes use of the deprecated command:

```
Warning: The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
```


## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-XXX)

Describe what you did and why.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
- You should have run `NOCOVERAGE=true rake rswag` to ensure the swagger docs are up-to-date
