### PR TITLE
Doorkeeper gem updates

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ ruby "3.1.3"
 gem "aws-sdk-s3", require: false
 gem "bootsnap", ">= 1.4.4", require: false
 gem "config"
-gem "doorkeeper", "~> 5.5.4", "< 5.6"
+gem "doorkeeper"
 gem "dotenv-rails"
 gem "net-imap"
 gem "net-pop"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -104,7 +104,7 @@ GEM
     docile (1.4.0)
     domain_name (0.5.20190701)
       unf (>= 0.0.5, < 1.0.0)
-    doorkeeper (5.5.4)
+    doorkeeper (5.6.2)
       railties (>= 5)
     dotenv (2.8.1)
     dotenv-rails (2.8.1)
@@ -410,7 +410,7 @@ DEPENDENCIES
   bootsnap (>= 1.4.4)
   byebug
   config
-  doorkeeper (~> 5.5.4, < 5.6)
+  doorkeeper
   dotenv-rails
   factory_bot_rails (>= 6.2.0)
   faker (>= 1.9.1)

--- a/config/initializers/doorkeeper.rb
+++ b/config/initializers/doorkeeper.rb
@@ -7,10 +7,10 @@ Doorkeeper.configure do
   # For more information go to
   # https://github.com/doorkeeper-gem/doorkeeper/wiki/Using-Scopes
   # https://doorkeeper.gitbook.io/guides/ruby-on-rails/scopes
-  # default_scopes
+  default_scopes :use_case_one, :use_case_two, :use_case_three, :use_case_four
 
   # other available scopes
-  optional_scopes :use_case_one, :use_case_two, :use_case_three, :use_case_four
+  # optional_scopes
 
   # ensures applications can only ask for configured scopes defined in default_scopes and optional_scopes
   # seems to me this would prevent different scopes being entered to try and escalate privilege or something


### PR DESCRIPTION
## What

When doorkeeper updated to 5.6.0 our tests started to fail so I raised an issue with the maintainer, we locked the version and moved on with our lives.

He responded a month or so later and I have only just seen his reply.



## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
- You should have run `NOCOVERAGE=true rake rswag` to ensure the swagger docs are up-to-date
