### PR TITLE
[AP-3590] Bump redis and postgres versions for test suite

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,8 +26,8 @@ executors:
           PGHOST: localhost
           PGUSER: user
           TZ: "Europe/London"
-      - image: cimg/redis:5.0
-      - image: cimg/postgres:10.18
+      - image: cimg/redis:6.2
+      - image: cimg/postgres:11.16
         environment:
           POSTGRES_USER: user
           POSTGRES_DB: laa_hmrc_interface_service_api_test


### PR DESCRIPTION
## What
Bump test suite redis and postgres versions

[Link to story](https://dsdmoj.atlassian.net/browse/AP-3590)

To match current postgres and target redis version

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
- You should have run `NOCOVERAGE=true rake rswag` to ensure the swagger docs are up-to-date
