### PR TITLE
[AP-3590] Bump sidekiq 6.5.7 --> 7.0.3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,7 +22,7 @@ gem "rswag-api"
 gem "rswag-ui"
 gem "sentry-rails"
 gem "sentry-ruby"
-gem "sidekiq"
+gem "sidekiq", "~> 7.0"
 gem "timeliness-i18n"
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -283,6 +283,8 @@ GEM
     rb-inotify (0.10.1)
       ffi (~> 1.0)
     redis (4.8.0)
+    redis-client (0.12.1)
+      connection_pool
     redis-namespace (1.10.0)
       redis (>= 4)
     regexp_parser (2.6.2)
@@ -368,10 +370,11 @@ GEM
     shellany (0.0.1)
     shoulda-matchers (5.3.0)
       activesupport (>= 5.2.0)
-    sidekiq (6.5.7)
-      connection_pool (>= 2.2.5)
-      rack (~> 2.0)
-      redis (>= 4.5.0, < 5)
+    sidekiq (7.0.3)
+      concurrent-ruby (< 2)
+      connection_pool (>= 2.3.0)
+      rack (>= 2.2.4)
+      redis-client (>= 0.11.0)
     simplecov (0.22.0)
       docile (~> 1.1)
       simplecov-html (~> 0.11)
@@ -445,7 +448,7 @@ DEPENDENCIES
   sentry-rails
   sentry-ruby
   shoulda-matchers
-  sidekiq
+  sidekiq (~> 7.0)
   simplecov
   simplecov-rcov
   spring

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -282,7 +282,8 @@ GEM
     rb-fsevent (0.11.2)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
-    redis (4.8.0)
+    redis (5.0.6)
+      redis-client (>= 0.9.0)
     redis-client (0.12.1)
       connection_pool
     redis-namespace (1.10.0)

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,1 +1,3 @@
-Sidekiq.logger = Rails.logger
+Sidekiq.configure_server do |cfg|
+  cfg.logger = Rails.logger
+end

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,3 +1,8 @@
-Sidekiq.configure_server do |cfg|
-  cfg.logger = Rails.logger
+Sidekiq.configure_server do |config|
+  config.logger = Rails.logger
+end
+
+Sidekiq.configure_client do |config|
+  config.logger = Rails.logger
+  config.logger.level = Logger::WARN # prevent info output in tests
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -30,6 +30,7 @@ unless ENV["NOCOVERAGE"]
   SimpleCov.start do
     add_filter "spec/"
     add_filter "initializers/config.rb"
+    add_filter "initializers/sidekiq.rb"
     add_filter "initializers/sidekiq_middleware.rb"
     add_filter "services/smoke_test.rb"
     add_filter "services/test_submission.rb"


### PR DESCRIPTION
## What
bump sidekiq 6.5.7 to 7.0.3

[Link to story](https://dsdmoj.atlassian.net/browse/AP-3590)

Following redis migration from 4.0.10 to 6.2.6 we can now update to
latest version of sidekiq.

see https://github.com/mperham/sidekiq/blob/main/docs/7.0-API-Migration.md
and https://github.com/mperham/sidekiq/blob/main/docs/7.0-Upgrade.md

## Testing
_Have tested on branch and sidekiq web ui and pod logs all reporting successful job processing_


## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
- You should have run `NOCOVERAGE=true rake rswag` to ensure the swagger docs are up-to-date
