### PR TITLE
Update smoke-test fail-emoji

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -177,7 +177,7 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": ":nope: Smoke test of use case << parameters.use_case >> on sandbox failed!"
+                    "text": ":nope-9607: Smoke test of use case << parameters.use_case >> on sandbox failed!"
                   }
                 }
               ]


### PR DESCRIPTION


## What

After the Slack enterprise merging the old, :nope: emoji was replaced with a weird grey thing.
This replaces it with the original red-ex-in-a-circle version


## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
- You should have run `NOCOVERAGE=true rake rswag` to ensure the swagger docs are up-to-date
