### PR TITLE
Add a "live" version of swagger docs

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -39,8 +39,12 @@ Rails/CreateTableWithTimestamps:
 RSpec/EmptyExampleGroup:
   Exclude:
     - 'spec/requests/api/v1/submissions_swagger_spec.rb'
-    - 'spec/requests/smoke_test_swagger_spec.rb'
+    - 'spec/requests/api/v1/smoke_test_swagger_spec.rb'
+
+RSpec/SharedContext:
+    Exclude:
+    - 'spec/requests/api/v1/submissions_swagger_spec.rb'
 
 RSpec/ScatteredSetup:
   Exclude:
-    - 'spec/requests/smoke_test_swagger_spec.rb'
+    - 'spec/requests/api/v1/smoke_test_swagger_spec.rb'

--- a/config/initializers/rswag_ui.rb
+++ b/config/initializers/rswag_ui.rb
@@ -5,7 +5,8 @@ Rswag::Ui.configure do |c|
   # NOTE: If you're using rspec-api to expose Swagger files (under swagger_root) as JSON or YAML endpoints,
   # then the list below should correspond to the relative paths for those endpoints
 
-  c.swagger_endpoint "/api-docs/v1/swagger.yaml", "API V1 Docs"
+  c.swagger_endpoint "/api-docs/v1/live/swagger.yaml", "API V1 Docs"
+  c.swagger_endpoint "/api-docs/v1/swagger.yaml", "API V1 Docs (incl. smoke tests)" if Settings.environment.eql?("non-live")
 
   # Add Basic Auth in case your API is private
   # c.basic_auth_enabled = true

--- a/spec/requests/api/v1/smoke_test_swagger_spec.rb
+++ b/spec/requests/api/v1/smoke_test_swagger_spec.rb
@@ -1,6 +1,6 @@
 require "swagger_helper"
 
-RSpec.describe "smoke_test", type: :request, swagger_doc: "v1/swagger.yaml" do
+RSpec.describe "Generate smoke_test swagger docs", type: :request, swagger_doc: "v1/swagger.yaml" do
   let(:use_case) { "one" }
 
   path "/smoke-test/{use_case}" do

--- a/spec/requests/api/v1/submissions_swagger_spec.rb
+++ b/spec/requests/api/v1/submissions_swagger_spec.rb
@@ -1,243 +1,259 @@
 require "rails_helper"
 require "swagger_helper"
 
-RSpec.describe "GET submission", type: :request, swagger_doc: "v1/swagger.yaml" do
-  include AuthorisedRequestHelper
+RSpec.shared_examples "GET submission" do
+  describe "GET submission", type: :request do
+    include AuthorisedRequestHelper
 
-  let(:token) { application.access_tokens.create! }
-  let(:Authorization) { "Bearer #{token.token}" }
+    let(:token) { application.access_tokens.create! }
+    let(:Authorization) { "Bearer #{token.token}" }
 
-  context "when create is called" do
-    let(:application) { dk_application }
-    let(:use_case) { "one" }
-    let(:submission) do
-      {
-        filter: {
-          use_case: "one",
-          last_name: "Yorke",
-          first_name: "Langley",
-          nino: "MN212451D",
-          dob: "1992-07-22",
-          start_date: "2020-08-01",
-          end_date: "2020-10-01",
-        },
-      }
-    end
+    context "when create is called" do
+      let(:application) { dk_application }
+      let(:use_case) { "one" }
+      let(:submission) do
+        {
+          filter: {
+            use_case: "one",
+            last_name: "Yorke",
+            first_name: "Langley",
+            nino: "MN212451D",
+            dob: "1992-07-22",
+            start_date: "2020-08-01",
+            end_date: "2020-10-01",
+          },
+        }
+      end
 
-    path "/api/v1/submission/create/{use_case}" do
-      post("Create new submission") do
-        tags "Submissions"
-        produces "application/json"
-        consumes "application/json"
-        security [{ oAuth: [] }]
-        parameter name: :use_case,
-                  in: :path,
-                  required: true,
-                  type: :string,
-                  description: "The use case you wish to request",
-                  schema: { enum: %w[one two three four] }
-        parameter name: :submission,
-                  in: :body,
-                  required: true,
-                  schema: {
-                    type: :object,
-                    properties: {
-                      filter: {
-                        type: :object,
-                        properties: {
-                          first_name: { type: String, example: "Langley" },
-                          last_name: { type: String, example: "Yorke" },
-                          nino: { type: String, example: "MN212451D" },
-                          dob: { type: Date, example: "1992-07-22" },
-                          start_date: { type: Date, example: "2020-08-01" },
-                          end_date: { type: Date, example: "2020-10-01" },
+      path "/api/v1/submission/create/{use_case}" do
+        post("Create new submission") do
+          tags "Submissions"
+          produces "application/json"
+          consumes "application/json"
+          security [{ oAuth: [] }]
+          parameter name: :use_case,
+                    in: :path,
+                    required: true,
+                    type: :string,
+                    description: "The use case you wish to request",
+                    schema: { enum: %w[one two three four] }
+          parameter name: :submission,
+                    in: :body,
+                    required: true,
+                    schema: {
+                      type: :object,
+                      properties: {
+                        filter: {
+                          type: :object,
+                          properties: {
+                            first_name: { type: String, example: "Langley" },
+                            last_name: { type: String, example: "Yorke" },
+                            nino: { type: String, example: "MN212451D" },
+                            dob: { type: Date, example: "1992-07-22" },
+                            start_date: { type: Date, example: "2020-08-01" },
+                            end_date: { type: Date, example: "2020-10-01" },
+                          },
                         },
                       },
-                    },
-                  }
-        response(202, "Accepted") do
-          description "Create a submission record and start the HMRC process asynchronously"
-          after do |example|
-            example.metadata[:response][:content] = {
-              "application/json" => {
-                example: JSON.parse(response.body, symbolize_names: true),
-              },
-            }
-          end
-
-          run_test! do |response|
-            expect(response.media_type).to eq("application/json")
-            expect(response.body).to match(/id/)
-            expect(response.body).to match(/_links/)
-            json_response = JSON.parse(response.body)
-
-            expect(json_response["_links"].first["href"]).to eq "http://www.example.com/api/v1/submission/result/#{json_response['id']}"
-          end
-        end
-
-        response(401, "Error: Unauthorized") do
-          let(:Authorization) { nil }
-
-          run_test!
-        end
-
-        context "when use_case is bad" do
-          response(400, "Bad request") do
-            let(:application) { dk_application(%w[use_case_three]) }
-
-            run_test! do |response|
-              expect(response.media_type).to eq("application/json")
-              expect(response.body).to match(/Unauthorised use case/)
-            end
-          end
-        end
-
-        context "when data is bad" do
-          response(400, "Bad request") do
-            let(:submission) do
-              {
-                filter: {
-                  last_name: nil,
-                  first_name: nil,
-                  nino: "abc123",
-                  dob: "1234",
-                  start_date: nil,
-                  end_date: nil,
+                    }
+          response(202, "Accepted") do
+            description "Create a submission record and start the HMRC process asynchronously"
+            after do |example|
+              example.metadata[:response][:content] = {
+                "application/json" => {
+                  example: JSON.parse(response.body, symbolize_names: true),
                 },
               }
             end
+
             run_test! do |response|
-              errors = JSON.parse(response.body)
               expect(response.media_type).to eq("application/json")
-              expect(errors["first_name"]).to eq(["can't be blank"])
-              expect(errors["last_name"]).to eq(["can't be blank"])
-              expect(errors["nino"]).to eq(["is not valid"])
-              expect(errors["dob"]).to eq(["is not a valid date"])
-              expect(errors["start_date"]).to eq(["is not a valid date"])
-              expect(errors["end_date"]).to eq(["is not a valid date"])
+              expect(response.body).to match(/id/)
+              expect(response.body).to match(/_links/)
+              json_response = JSON.parse(response.body)
+
+              expect(json_response["_links"].first["href"]).to eq "http://www.example.com/api/v1/submission/result/#{json_response['id']}"
+            end
+          end
+
+          response(401, "Error: Unauthorized") do
+            let(:Authorization) { nil }
+
+            run_test!
+          end
+
+          context "when use_case is bad" do
+            response(400, "Bad request") do
+              let(:application) { dk_application(%w[use_case_three]) }
+
+              run_test! do |response|
+                expect(response.media_type).to eq("application/json")
+                expect(response.body).to match(/Unauthorised use case/)
+              end
+            end
+          end
+
+          context "when data is bad" do
+            response(400, "Bad request") do
+              let(:submission) do
+                {
+                  filter: {
+                    last_name: nil,
+                    first_name: nil,
+                    nino: "abc123",
+                    dob: "1234",
+                    start_date: nil,
+                    end_date: nil,
+                  },
+                }
+              end
+              run_test! do |response|
+                errors = JSON.parse(response.body)
+                expect(response.media_type).to eq("application/json")
+                expect(errors["first_name"]).to eq(["can't be blank"])
+                expect(errors["last_name"]).to eq(["can't be blank"])
+                expect(errors["nino"]).to eq(["is not valid"])
+                expect(errors["dob"]).to eq(["is not a valid date"])
+                expect(errors["start_date"]).to eq(["is not a valid date"])
+                expect(errors["end_date"]).to eq(["is not a valid date"])
+              end
+            end
+          end
+
+          context "when scope is invalid" do
+            response(400, "Bad request") do
+              let(:use_case) { "three" }
+              let(:application) { dk_application(%w[use_case_one use_case_two]) }
+
+              run_test! do |response|
+                expect(response.media_type).to eq("application/json")
+                expect(response.body).to match(/Unauthorised use case/)
+              end
             end
           end
         end
+      end
+    end
 
-        context "when scope is invalid" do
-          response(400, "Bad request") do
-            let(:use_case) { "three" }
-            let(:application) { dk_application(%w[use_case_one use_case_two]) }
+    context "when result is called" do
+      let(:application) { dk_application }
+      let(:id) { submission.id }
 
+      path "/api/v1/submission/result/{id}" do
+        get "Retrieves a submission" do
+          tags "Submissions"
+          produces "application/json"
+          consumes "application/json"
+          security [{ oAuth: [] }]
+          parameter name: :id, in: :path, type: :string
+
+          response 200, "Submission complete" do
+            let!(:submission) { create :submission, :completed, :with_attachment, oauth_application: application }
+            let(:expected_response) do
+              {
+                submission: "test-guid",
+                status: "completed",
+                data: [
+                  { correlation_id: "test-guid", use_case: "use_case_two" },
+                  { test_key: "test value" },
+                ],
+              }
+            end
             run_test! do |response|
               expect(response.media_type).to eq("application/json")
-              expect(response.body).to match(/Unauthorised use case/)
+              expect(JSON.parse(response.body).deep_symbolize_keys).to eq(expected_response)
+            end
+          end
+
+          response 200, "Submission failed" do
+            let!(:submission) { create :submission, :failed_with_attachment, oauth_application: application }
+            let(:expected_response) do
+              {
+                submission: "test-guid",
+                status: "failed",
+                data: [
+                  { correlation_id: "test-guid", use_case: "use_case_two" },
+                  { error: "submitted client details could not be found in HMRC service" },
+                ],
+              }
+            end
+            run_test! do |response|
+              expect(response.media_type).to eq("application/json")
+              expect(JSON.parse(response.body).deep_symbolize_keys).to eq(expected_response)
+            end
+          end
+
+          response 202, "Submission still processing" do
+            let!(:submission) { create :submission, :processing, oauth_application: application }
+            let(:expected_response) do
+              {
+                submission: id,
+                status: "processing",
+                _links: [href: "http://www.example.com/api/v1/submission/status/#{id}"],
+              }
+            end
+            run_test! do |response|
+              expect(response.media_type).to eq("application/json")
+              expect(JSON.parse(response.body, symbolize_names: true)).to eq(expected_response)
+            end
+          end
+
+          response 500, "Submission complete but no result object is present" do
+            let!(:submission) { create :submission, :completed, oauth_application: application }
+            let(:expected_response) do
+              {
+                submission: id,
+                status: "completed",
+                code: "INCOMPLETE_SUBMISSION",
+                message: "Process complete but no result available",
+              }
+            end
+            run_test! do
+              expect(response.media_type).to eq("application/json")
+              expect(JSON.parse(response.body).symbolize_keys).to eq(expected_response)
+            end
+          end
+
+          response 404, "Submission not found" do
+            let(:id) { "1234" }
+            run_test!
+          end
+
+          response 401, "Error: Unauthorized" do
+            let(:id) { "1234" }
+            let(:Authorization) { nil }
+            run_test!
+          end
+
+          context "when application is not the application that created the submission" do
+            response(400, "Bad request") do
+              let(:submitting_application) { dk_application }
+              let(:submission) do
+                create :submission, :processing, oauth_application: submitting_application
+              end
+
+              run_test! do |response|
+                expect(response.media_type).to eq("application/json")
+                expect(response.body).to match(/Unauthorised application/)
+              end
             end
           end
         end
       end
     end
   end
+end
 
-  context "when result is called" do
-    let(:application) { dk_application }
-    let(:id) { submission.id }
+# This generates submissions endpoints for swagger in two sets of swagger
+# docs because production environment only shows the "v1/live/swagger.yaml"
+# version, staging and UAT shows the "v1/swagger.yaml" version
+#
+RSpec.describe "Generate submission swagger docs" do
+  context "with API V1 Docs", type: :request, swagger_doc: "v1/live/swagger.yaml" do
+    include_examples "GET submission"
+  end
 
-    path "/api/v1/submission/result/{id}" do
-      get "Retrieves a submission" do
-        tags "Submissions"
-        produces "application/json"
-        consumes "application/json"
-        security [{ oAuth: [] }]
-        parameter name: :id, in: :path, type: :string
-
-        response 200, "Submission complete" do
-          let!(:submission) { create :submission, :completed, :with_attachment, oauth_application: application }
-          let(:expected_response) do
-            {
-              submission: "test-guid",
-              status: "completed",
-              data: [
-                { correlation_id: "test-guid", use_case: "use_case_two" },
-                { test_key: "test value" },
-              ],
-            }
-          end
-          run_test! do |response|
-            expect(response.media_type).to eq("application/json")
-            expect(JSON.parse(response.body).deep_symbolize_keys).to eq(expected_response)
-          end
-        end
-
-        response 200, "Submission failed" do
-          let!(:submission) { create :submission, :failed_with_attachment, oauth_application: application }
-          let(:expected_response) do
-            {
-              submission: "test-guid",
-              status: "failed",
-              data: [
-                { correlation_id: "test-guid", use_case: "use_case_two" },
-                { error: "submitted client details could not be found in HMRC service" },
-              ],
-            }
-          end
-          run_test! do |response|
-            expect(response.media_type).to eq("application/json")
-            expect(JSON.parse(response.body).deep_symbolize_keys).to eq(expected_response)
-          end
-        end
-
-        response 202, "Submission still processing" do
-          let!(:submission) { create :submission, :processing, oauth_application: application }
-          let(:expected_response) do
-            {
-              submission: id,
-              status: "processing",
-              _links: [href: "http://www.example.com/api/v1/submission/status/#{id}"],
-            }
-          end
-          run_test! do |response|
-            expect(response.media_type).to eq("application/json")
-            expect(JSON.parse(response.body, symbolize_names: true)).to eq(expected_response)
-          end
-        end
-
-        response 500, "Submission complete but no result object is present" do
-          let!(:submission) { create :submission, :completed, oauth_application: application }
-          let(:expected_response) do
-            {
-              submission: id,
-              status: "completed",
-              code: "INCOMPLETE_SUBMISSION",
-              message: "Process complete but no result available",
-            }
-          end
-          run_test! do
-            expect(response.media_type).to eq("application/json")
-            expect(JSON.parse(response.body).symbolize_keys).to eq(expected_response)
-          end
-        end
-
-        response 404, "Submission not found" do
-          let(:id) { "1234" }
-          run_test!
-        end
-
-        response 401, "Error: Unauthorized" do
-          let(:id) { "1234" }
-          let(:Authorization) { nil }
-          run_test!
-        end
-
-        context "when application is not the application that created the submission" do
-          response(400, "Bad request") do
-            let(:submitting_application) { dk_application }
-            let(:submission) do
-              create :submission, :processing, oauth_application: submitting_application
-            end
-
-            run_test! do |response|
-              expect(response.media_type).to eq("application/json")
-              expect(response.body).to match(/Unauthorised application/)
-            end
-          end
-        end
-      end
-    end
+  context "with API V1 Docs (incl. smoke tests)", type: :request, swagger_doc: "v1/swagger.yaml" do
+    include_examples "GET submission"
   end
 end

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -38,6 +38,30 @@ RSpec.configure do |config|
         },
       },
     },
+
+    "v1/live/swagger.yaml" => {
+      openapi: "3.0.1",
+      info: {
+        title: "LAA HMRC Interface Service",
+        description: "This Service facilitates the HMRC API access for the LAA Use Cases",
+        version: "v1/live",
+      },
+      paths: {},
+      components: {
+        securitySchemes: {
+          oAuth: {
+            in: :header,
+            type: :oauth2,
+            description: "OAuth2 client credentials flow",
+            flows: {
+              clientCredentials: {
+                tokenUrl: "/oauth/token",
+              },
+            },
+          },
+        },
+      },
+    },
   }
 
   # Specify the format of the output Swagger file when running 'rswag:specs:swaggerize'.

--- a/swagger/v1/live/swagger.yaml
+++ b/swagger/v1/live/swagger.yaml
@@ -3,69 +3,8 @@ openapi: 3.0.1
 info:
   title: LAA HMRC Interface Service
   description: This Service facilitates the HMRC API access for the LAA Use Cases
-  version: v1
+  version: v1/live
 paths:
-  "/smoke-test/{use_case}":
-    get:
-      summary: individual use_case smoke-test
-      description: Run a smoke test for chosen use_case
-      tags:
-      - Smoke tests
-      parameters:
-      - name: use_case
-        in: path
-        required: true
-        schema:
-          type: string
-      responses:
-        '200':
-          description: success
-          content:
-            application/json:
-              examples:
-                example_0:
-                  value:
-                    smoke_test_one_result: true
-        '500':
-          description: internal server error
-          content:
-            application/json:
-              examples:
-                example_0:
-                  value:
-                    smoke_test_one_result: false
-  "/smoke-test":
-    get:
-      summary: call smoke_test
-      description: Fetch smoke_test results that have been generated within the last
-        hour
-      tags:
-      - Smoke tests
-      responses:
-        '200':
-          description: success
-          content:
-            application/json:
-              examples:
-                example_0:
-                  value:
-                    smoke_test_result:
-                      use_case_one: true
-                      use_case_two: true
-                      use_case_three: true
-                      use_case_four: true
-        '500':
-          description: internal server error
-          content:
-            application/json:
-              examples:
-                example_0:
-                  value:
-                    smoke_test_result:
-                      use_case_one: false
-                      use_case_two: true
-                      use_case_three: true
-                      use_case_four: true
   "/api/v1/submission/create/{use_case}":
     post:
       summary: Create new submission


### PR DESCRIPTION

## What
Add different version of swagger docs for "live" production host

These are to exclude the smoke test endpoints because
a. they should not be used against production/live
b. their routes are deactivated on prodiction/live anyway

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
- You should have run `NOCOVERAGE=true rake rswag` to ensure the swagger docs are up-to-date
