### PR TITLE
.gitignore redis binary dump files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,7 @@ config/environments/*.local.yml
 
 # ignore legacy script outputs
 user_data/**.*
+
+# Ignore Redis binary dump (dump.rdb) files
+*.rdb
+


### PR DESCRIPTION
## What
gitignore redis binary dump file

Should be ignored since we use redis and can run it locally
but do not want to share them.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
- You should have run `NOCOVERAGE=true rake rswag` to ensure the swagger docs are up-to-date
