### PR TITLE
Fix: update cloud platform docker image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ executors:
       - image: cimg/base:2021.04
   cloud-platform-executor:
     docker:
-      - image: ministryofjustice/cloud-platform-tools:2.1
+      - image: ministryofjustice/cloud-platform-tools:2.3.0
         environment:
           GITHUB_TEAM_NAME_SLUG: laa-apply-for-legal-aid
           TZ: Europe/London
@@ -36,7 +36,6 @@ references:
     run:
       name: Build docker image
       command: |
-        $(aws ecr get-login --no-include-email)
         docker build \
         --build-arg BUILD_DATE=$(date +%Y-%m-%dT%H:%M:%S%z) \
         --build-arg BUILD_TAG="app-${CIRCLE_SHA1}" \
@@ -46,6 +45,7 @@ references:
     run:
       name: Push image to ecr repo
       command: |
+        aws ecr get-login-password --region eu-west-2 | docker login --username AWS --password-stdin ${ECR_ENDPOINT}
         docker tag app "${ECR_ENDPOINT}/laa-apply-for-legal-aid/laa-hmrc-interface-uat-ecr:${CIRCLE_SHA1}"
         docker push "${ECR_ENDPOINT}/laa-apply-for-legal-aid/laa-hmrc-interface-uat-ecr:${CIRCLE_SHA1}"
 


### PR DESCRIPTION
## What

After a github SSH key update, checking if an update to cloud-platform docker image helps

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
- You should have run `NOCOVERAGE=true rake rswag` to ensure the swagger docs are up-to-date
