### PR TITLE
Fix delete_ecr_images

### DIFF
--- a/bin/delete_ecr_images
+++ b/bin/delete_ecr_images
@@ -12,7 +12,7 @@ puts "ECR has #{images.count} images"
 
 images_to_delete = []
 images.each do |i|
-  date_pushed = DateTime.strptime(i['imagePushedAt'].to_s, '%s')
+  date_pushed = DateTime.strptime(i['imagePushedAt'], '%Y-%m-%dT%H:%M:%S%z')
   age_in_days = (DateTime.now - date_pushed).to_i
   images_to_delete << i if age_in_days > delete_if_older_than
 end


### PR DESCRIPTION
## What

delete_ecr_images was incorrectly evaluating date pushed.

`DateTime.strptime(i['imagePushedAt'].to_s, '%s') `was being evaluated to 1970-01-01, meaning that images were always > 10 days old. This meant all images were deleted nightly and not just those > 10 days old.

I believe this issue affects all the apply repos that use the same (or similar) script.

Describe what you did and why.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
- You should have run `NOCOVERAGE=true rake rswag` to ensure the swagger docs are up-to-date
