### PR TITLE
Amend swagger document using rswag

### DIFF
--- a/spec/requests/api/v1/submissions_swagger_spec.rb
+++ b/spec/requests/api/v1/submissions_swagger_spec.rb
@@ -147,39 +147,45 @@ RSpec.shared_examples "GET submission" do
           security [{ oAuth: [] }]
           parameter name: :id, in: :path, type: :string
 
-          response 200, "Submission complete" do
-            let!(:submission) { create :submission, :completed, :with_attachment, oauth_application: application }
-            let(:expected_response) do
-              {
-                submission: "test-guid",
-                status: "completed",
-                data: [
-                  { correlation_id: "test-guid", use_case: "use_case_two" },
-                  { test_key: "test value" },
-                ],
-              }
-            end
-            run_test! do |response|
-              expect(response.media_type).to eq("application/json")
-              expect(JSON.parse(response.body).deep_symbolize_keys).to eq(expected_response)
-            end
-          end
+          response 200, "Submission completed or failed" do
+            context "when completed with attachment" do
+              let(:submission) { create :submission, :completed, :with_attachment, oauth_application: application }
 
-          response 200, "Submission failed" do
-            let!(:submission) { create :submission, :failed_with_attachment, oauth_application: application }
-            let(:expected_response) do
-              {
-                submission: "test-guid",
-                status: "failed",
-                data: [
-                  { correlation_id: "test-guid", use_case: "use_case_two" },
-                  { error: "submitted client details could not be found in HMRC service" },
-                ],
-              }
+              let(:expected_response) do
+                {
+                  submission: "test-guid",
+                  status: "completed",
+                  data: [
+                    { correlation_id: "test-guid", use_case: "use_case_two" },
+                    { test_key: "test value" },
+                  ],
+                }
+              end
+
+              run_test! do |response|
+                expect(response.media_type).to eq("application/json")
+                expect(JSON.parse(response.body).deep_symbolize_keys).to eq(expected_response)
+              end
             end
-            run_test! do |response|
-              expect(response.media_type).to eq("application/json")
-              expect(JSON.parse(response.body).deep_symbolize_keys).to eq(expected_response)
+
+            context "when failed with attachment" do
+              let(:submission) { create :submission, :failed_with_attachment, oauth_application: application }
+
+              let(:expected_response) do
+                {
+                  submission: "test-guid",
+                  status: "failed",
+                  data: [
+                    { correlation_id: "test-guid", use_case: "use_case_two" },
+                    { error: "submitted client details could not be found in HMRC service" },
+                  ],
+                }
+              end
+
+              run_test! do |response|
+                expect(response.media_type).to eq("application/json")
+                expect(JSON.parse(response.body).deep_symbolize_keys).to eq(expected_response)
+              end
             end
           end
 

--- a/swagger/v1/live/swagger.yaml
+++ b/swagger/v1/live/swagger.yaml
@@ -75,7 +75,7 @@ paths:
           type: string
       responses:
         '200':
-          description: Submission failed
+          description: Submission completed or failed
         '202':
           description: Submission still processing
         '500':


### PR DESCRIPTION
## What
Add swagger comment via rswag and specs, not by amending the static `swagger.yaml`

A previous commit amended the static swagger yaml
which is overwritten by `rake rswag`. Swagger
comments need to be applied via test instead when
using rswag. This meant nesting the tests as there
are separate tests for failed and completed scenarios -
previous incarnation meant last run test for response 200
"won".

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
- You should have run `NOCOVERAGE=true rake rswag` to ensure the swagger docs are up-to-date
