### PR TITLE
AP-4043: correct link reference in result response

### DIFF
--- a/app/controllers/api/V1/submissions_controller.rb
+++ b/app/controllers/api/V1/submissions_controller.rb
@@ -45,7 +45,7 @@ module Api
                     elsif completed_but_no_attachment?
                       { code: "INCOMPLETE_SUBMISSION", message: "Process complete but no result available" }
                     else
-                      { _links: [href: "#{request.base_url}/api/v1/submission/status/#{submission.id}"] }
+                      { _links: [href: "#{request.base_url}/api/v1/submission/result/#{submission.id}"] }
                     end
         { submission: submission.id, status: submission.status }.merge(data_hash)
       end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -32,7 +32,6 @@ Rails.application.routes.draw do
   namespace :api do
     namespace :v1 do
       post "submission/create/:use_case", to: "submissions#create", format: :json
-      get "submission/status/:id", to: "submissions#status", as: "submission-status-id", format: :json
       get "submission/result/:id", to: "submissions#result", as: "submission-result-id", format: :json
       get "use_case/one", to: "use_case#one", format: :json
       get "use_case/two", to: "use_case#two", format: :json

--- a/spec/requests/api/v1/submissions_swagger_spec.rb
+++ b/spec/requests/api/v1/submissions_swagger_spec.rb
@@ -195,7 +195,7 @@ RSpec.shared_examples "GET submission" do
               {
                 submission: id,
                 status: "processing",
-                _links: [href: "http://www.example.com/api/v1/submission/status/#{id}"],
+                _links: [href: "http://www.example.com/api/v1/submission/result/#{id}"],
               }
             end
             run_test! do |response|


### PR DESCRIPTION


## What
Correct invalid link reference in result response body

[Link to story](https://dsdmoj.atlassian.net/browse/AP-4043)

The result response `_link` should refer to the ap/v1/submission#result
action, not the defunct ap/v1/submission#status action.

This corrects the link and removes the defunct route

- AP-4043: fix link references url in result endpoints response
- AP-4043: Remove route with no action


## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
- You should have run `NOCOVERAGE=true rake rswag` to ensure the swagger docs are up-to-date
