### PR TITLE
AP-4043: fix ActiveRecord::RecordNotUnique on index_active_storage_blobs_on_key

### DIFF
--- a/app/services/submission_service.rb
+++ b/app/services/submission_service.rb
@@ -22,7 +22,9 @@ class SubmissionService
     @result[:data] << { error: "submitted client details could not be found in HMRC service" }
     raise
   ensure
-    @submission.result.attach(io: StringIO.new(@result.to_json), filename: "#{@submission.id}.json",
-                              content_type: "application/json", key: "submission/result/#{@submission.id}")
+    @submission.result.attach(io: StringIO.new(@result.to_json),
+                              filename: "#{@submission.id}.json",
+                              content_type: "application/json",
+                              key: "submission/result/#{@submission.id}-attached-at-#{Time.current.to_i}")
   end
 end

--- a/app/services/submission_service.rb
+++ b/app/services/submission_service.rb
@@ -25,6 +25,6 @@ class SubmissionService
     @submission.result.attach(io: StringIO.new(@result.to_json),
                               filename: "#{@submission.id}.json",
                               content_type: "application/json",
-                              key: "submission/result/#{@submission.id}-attached-at-#{Time.current.to_i}")
+                              key: "submission/result/#{@submission.id}-attached-at-#{Time.current.to_f}")
   end
 end

--- a/spec/services/submission_service_spec.rb
+++ b/spec/services/submission_service_spec.rb
@@ -45,8 +45,7 @@ RSpec.describe SubmissionService, vcr: { cassette_name: "use_case_one_success" }
       expect(submission.result.content_type).to eq "application/json"
     end
 
-    context "when the details are complete but not found on the calling service",
-            vcr: { cassette_name: "use_case_one_fail" } do
+    context "when the details are complete but not found on the calling service", vcr: { cassette_name: "use_case_one_fail" } do
       let(:data) do
         {
           use_case: "one",

--- a/spec/services/submission_service_spec.rb
+++ b/spec/services/submission_service_spec.rb
@@ -35,9 +35,12 @@ RSpec.describe SubmissionService, vcr: { cassette_name: "use_case_one_success" }
       expect(submission.result.filename).to eq "#{submission.id}.json"
     end
 
-    it "gives the submission result attachment a key" do
-      call
-      expect(submission.result.key).to eq "submission/result/#{submission.id}"
+    it "gives the submission result attachment a unique key with prefix" do
+      freeze_time do
+        timestamp = Time.current.to_f
+        call
+        expect(submission.result.key).to eql("submission/result/#{submission.id}-attached-at-#{timestamp}")
+      end
     end
 
     it "gives the submission result attachment a content type" do

--- a/spec/support/time_helpers.rb
+++ b/spec/support/time_helpers.rb
@@ -1,0 +1,3 @@
+RSpec.configure do |config|
+  config.include ActiveSupport::Testing::TimeHelpers
+end


### PR DESCRIPTION
## What
Fix active storage record not unique error

[Relates/identified-by story](https://dsdmoj.atlassian.net/browse/AP-4043)

This error is raised intermittently and causing the result request to get
stuck

```shell
ActiveRecord::RecordNotUnique: PG::UniqueViolation: ERROR: duplicate key value violates unique constraint "index_active_storage_blobs_on_key" DETAIL: Key (key)=(submission/result/a1583034-2d20-47c6-a...
```
It is caused by repeated calls to the same service class resulting in an `attach` command call
to replace an existing attachment at the same exact key.

when replacing an attachment, activestorage creates a new attachment with a new unique key and purges
the original attachment with the old key using :purge_later.

This, however, relies on unique keys being generated for every `attach` command call. Since we use a
custom key that is not unique on every call this logic is broken and the "new" key name will immediately
be violating "index_active_storage_blobs_on_key" and raise an error to that effect.

To fix: generate a unique custom key, for each call, by appending a unique value, such as a monotonic timestamp.

```
key: "submission/result/#{submission_id}-#{always_unique_value}"
```

Note that we need the prefix of "submission/result/" for infrastructure code that deletes any s3 bucket with that
prefix after x days.

## Testing

I have tested this locally using the Assurance tool submitting 35 submissions/request. It takes approx 2-4 minutes to complete with no `ActiveRecord::RecordNotUnique` (whereas without this fix it raised the error ~90% of the time).

If you want to test against UAT you can do so by using the Assurance tool. Speak to me for help with setup if necessary.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
- You should have run `NOCOVERAGE=true rake rswag` to ensure the swagger docs are up-to-date
