### PR TITLE
Have dependabot ignore doorkeeper 5.6+ updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,3 +10,6 @@ updates:
     timezone: Europe/London
   open-pull-requests-limit: 5
   target-branch: main
+  ignore:
+    - dependency-name: "doorkeeper"
+      versions: ["~> 5.5.4"]


### PR DESCRIPTION
## What
Have dependabot ignore doorkeeper 5.6+ updates

[Link to story](https://dsdmoj.atlassian.net/browse/AP-XXX)

~> 5.5.4 (equivalent to >= 5.5.4, < 5.6)

5.6 results in scope errors and codebase needs to change to handle
this before we can bump.

example of error
```
OAuth2::Error: invalid_scope: The requested scope is invalid, unknown, or malformed. {"error":"invalid_scope","error_description":"The requested scope is invalid, unknown, or malformed."}
```

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
- You should have run `NOCOVERAGE=true rake rswag` to ensure the swagger docs are up-to-date
