### PR TITLE
Add a bin/dev command for running locally

### DIFF
--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,0 +1,7 @@
+web: unset PORT && bin/rails server -p 4032
+sidekiq-default: bundle exec sidekiq -c 5 -q default
+sidekiq-uc1: bundle exec sidekiq -c 1 -q uc-one-submissions
+sidekiq-uc2: bundle exec sidekiq -c 1 -q uc-two-submissions
+sidekiq-uc3: bundle exec sidekiq -c 1 -q uc-three-submissions
+sidekiq-uc4: bundle exec sidekiq -c 1 -q uc-four-submissions
+redis: redis-server --port 6380

--- a/bin/dev
+++ b/bin/dev
@@ -1,0 +1,8 @@
+#!/usr/bin/env sh
+
+if ! gem list foreman -i --silent; then
+  echo "Installing foreman..."
+  gem install foreman
+fi
+
+exec foreman start -f Procfile.dev "$@"

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,8 +1,10 @@
 Sidekiq.configure_server do |config|
   config.logger = Rails.logger
+  config.redis = { url: "redis://127.0.0.1:6380/5" } if Rails.env.development?
 end
 
 Sidekiq.configure_client do |config|
   config.logger = Rails.logger
   config.logger.level = Logger::WARN # prevent info output in tests
+  config.redis = { url: "redis://127.0.0.1:6380/5" } if Rails.env.development?
 end

--- a/docs/development.md
+++ b/docs/development.md
@@ -9,7 +9,10 @@
 * Run `git-crypt unlock ~/path/to/symmetric_key`
 * Run `rake db:reset`, this will create, migrate and seed the database
 * Run the tests with `bundle exec rspec`
-* Run the server with `bundle exec rails s`
+* Run the server with `bundle exec rails s` \*
+
+
+\* _Alternatively you can run the server with `bin/dev` which will set the web server port to 4032 and the redis server to 6380 (using non-default database number, 5) and mimic production-like queues and concurrency._
 
 ## Applications
 


### PR DESCRIPTION
## What
Add bin/dev command to run service locally for easier consumption

Came out of work done on https://github.com/ministryofjustice/laa-assure-hmrc-data
for which testing locally in a production like manner was helpful

This runs the app in a manner that emulates how
it runs in production (with 5 unique queues with matching
concurrency). It further isolates its local redis database
and web port from other local redis databases and web ports
so you can run a consumer app locally and still monitor the
queues through the app specific sidekiq web UIs.

**IMPORTANT**
The `bin/dev` command:
- runs the app on port 4032 to avoid clashes with other local services
- runs the redis-server on port 6380 to avoid clashes with other local services using redis-server
- runs the redis-server against database 5, to avoid clash with typical default of [database] 1 - _prevents web ui seeing other queues etc._
- runs a worker per use case (4 total), each with concurrency of 1, to emulate production behaviour

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
- You should have run `NOCOVERAGE=true rake rswag` to ensure the swagger docs are up-to-date
