### PR TITLE
Remove Doorkeeper from dependabot ignore

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,3 @@ updates:
     timezone: Europe/London
   open-pull-requests-limit: 5
   target-branch: main
-  ignore:
-    - dependency-name: "doorkeeper"
-      versions: ["~> 5.5.4"]


### PR DESCRIPTION
## What

While we were locked at an earlier version we told dependabot to ignore the gem completely.  This removes it so we can follow the live updates again

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
- You should have run `NOCOVERAGE=true rake rswag` to ensure the swagger docs are up-to-date
