### PR TITLE
AP-4295: Add aws cli setup using short-lived credentials

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,9 @@
 version: 2.1
 
 orbs:
+  aws-cli: circleci/aws-cli@4.0.0
   slack: circleci/slack@4.5.2
+
 executors:
   basic-executor:
     docker:
@@ -31,6 +33,7 @@ executors:
         environment:
           POSTGRES_USER: user
           POSTGRES_DB: laa_hmrc_interface_service_api_test
+
 references:
   build_docker_image: &build_docker_image
     run:
@@ -98,6 +101,11 @@ references:
         bundle exec rake db:migrate
 
 commands:
+  aws-cli-setup:
+    steps:
+     - aws-cli/setup:
+        role_arn: $ECR_ROLE_TO_ASSUME
+        region: $ECR_REGION
   run-smoke-test:
     parameters:
       use_case:
@@ -105,6 +113,7 @@ commands:
         default: expect_fail
     steps:
       - run: ./bin/smoke_tests << parameters.use_case >>
+
 jobs:
   lint_checks:
     executor: linting-executor
@@ -199,6 +208,7 @@ jobs:
           version: 20.10.7
       - *decrypt_secrets
       - *build_docker_image
+      - aws-cli-setup
       - *push_to_ecr
   deploy_uat: &deploy_uat
     executor: cloud-platform-executor

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,18 +44,6 @@ references:
         --build-arg BUILD_TAG="app-${CIRCLE_SHA1}" \
         --build-arg APP_BRANCH=${CIRCLE_BRANCH} \
         -t app .
-  push_to_ecr: &push_to_ecr
-    run:
-      name: Push image to ecr repo
-      command: |
-        aws ecr get-login-password --region $ECR_REGION | docker login --username AWS --password-stdin ${ECR_REGISTRY}
-        docker tag app "${ECR_REGISTRY}/${ECR_REPOSITORY}:${CIRCLE_SHA1}"
-        docker push "${ECR_REGISTRY}/${ECR_REPOSITORY}:${CIRCLE_SHA1}"
-
-        if [ "${CIRCLE_BRANCH}" == "main" ]; then
-          docker tag app "${ECR_REGISTRY}/${ECR_REPOSITORY}:latest"
-          docker push "${ECR_REGISTRY}/${ECR_REPOSITORY}:latest"
-        fi
   authenticate_k8s_live: &authenticate_k8s_live
     run:
       name: Authenticate with Live cluster
@@ -101,11 +89,23 @@ references:
         bundle exec rake db:migrate
 
 commands:
-  aws-cli-setup:
+  push-to-ecr:
+    description: "Authenticate and push image to ECR repository"
     steps:
-     - aws-cli/setup:
-        role_arn: $ECR_ROLE_TO_ASSUME
-        region: $ECR_REGION
+      - aws-cli/setup:
+          role_arn: $ECR_ROLE_TO_ASSUME
+          region: $ECR_REGION
+      - run:
+          name: Push image to ECR repository
+          command: |
+            aws ecr get-login-password --region $ECR_REGION | docker login --username AWS --password-stdin ${ECR_REGISTRY}
+            docker tag app "${ECR_REGISTRY}/${ECR_REPOSITORY}:${CIRCLE_SHA1}"
+            docker push "${ECR_REGISTRY}/${ECR_REPOSITORY}:${CIRCLE_SHA1}"
+
+            if [ "${CIRCLE_BRANCH}" == "main" ]; then
+              docker tag app "${ECR_REGISTRY}/${ECR_REPOSITORY}:latest"
+              docker push "${ECR_REGISTRY}/${ECR_REPOSITORY}:latest"
+            fi
   run-smoke-test:
     parameters:
       use_case:
@@ -208,8 +208,7 @@ jobs:
           version: 20.10.7
       - *decrypt_secrets
       - *build_docker_image
-      - aws-cli-setup
-      - *push_to_ecr
+      - push-to-ecr
   deploy_uat: &deploy_uat
     executor: cloud-platform-executor
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,13 +48,13 @@ references:
     run:
       name: Push image to ecr repo
       command: |
-        aws ecr get-login-password --region eu-west-2 | docker login --username AWS --password-stdin ${ECR_ENDPOINT}
-        docker tag app "${ECR_ENDPOINT}/laa-apply-for-legal-aid/laa-hmrc-interface-uat-ecr:${CIRCLE_SHA1}"
-        docker push "${ECR_ENDPOINT}/laa-apply-for-legal-aid/laa-hmrc-interface-uat-ecr:${CIRCLE_SHA1}"
+        aws ecr get-login-password --region $ECR_REGION | docker login --username AWS --password-stdin ${ECR_REGISTRY}
+        docker tag app "${ECR_REGISTRY}/${ECR_REPOSITORY}:${CIRCLE_SHA1}"
+        docker push "${ECR_REGISTRY}/${ECR_REPOSITORY}:${CIRCLE_SHA1}"
 
         if [ "${CIRCLE_BRANCH}" == "main" ]; then
-          docker tag app "${ECR_ENDPOINT}/laa-apply-for-legal-aid/laa-hmrc-interface-uat-ecr:latest"
-          docker push "${ECR_ENDPOINT}/laa-apply-for-legal-aid/laa-hmrc-interface-uat-ecr:latest"
+          docker tag app "${ECR_REGISTRY}/${ECR_REPOSITORY}:latest"
+          docker push "${ECR_REGISTRY}/${ECR_REPOSITORY}:latest"
         fi
   authenticate_k8s_live: &authenticate_k8s_live
     run:
@@ -241,7 +241,7 @@ jobs:
                           --install --wait \
                           --namespace=${K8S_NAMESPACE} \
                           --values ./deploy/helm/values-staging.yaml \
-                          --set image.repository="$ECR_ENDPOINT/laa-apply-for-legal-aid/laa-hmrc-interface-uat-ecr" \
+                          --set image.repository="${ECR_REGISTRY}/${ECR_REPOSITORY}" \
                           --set image.tag="${CIRCLE_SHA1}"
   deploy_production:
     executor: cloud-platform-executor
@@ -258,7 +258,7 @@ jobs:
                         --install --wait \
                         --namespace=${K8S_NAMESPACE} \
                         --values ./deploy/helm/values-production.yaml \
-                        --set image.repository="$ECR_ENDPOINT/laa-apply-for-legal-aid/laa-hmrc-interface-uat-ecr" \
+                        --set image.repository="${ECR_REGISTRY}/${ECR_REPOSITORY}" \
                         --set image.tag="${CIRCLE_SHA1}"
       - slack/notify:
           event: fail

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,15 +35,6 @@ executors:
           POSTGRES_DB: laa_hmrc_interface_service_api_test
 
 references:
-  build_docker_image: &build_docker_image
-    run:
-      name: Build docker image
-      command: |
-        docker build \
-        --build-arg BUILD_DATE=$(date +%Y-%m-%dT%H:%M:%S%z) \
-        --build-arg BUILD_TAG="app-${CIRCLE_SHA1}" \
-        --build-arg APP_BRANCH=${CIRCLE_BRANCH} \
-        -t app .
   authenticate_k8s_live: &authenticate_k8s_live
     run:
       name: Authenticate with Live cluster
@@ -89,9 +80,17 @@ references:
         bundle exec rake db:migrate
 
 commands:
-  push-to-ecr:
-    description: "Authenticate and push image to ECR repository"
+  build-and-push-to-ecr:
+    description: Build and push image to ECR repository
     steps:
+      - run:
+          name: Build docker image
+          command: |
+            docker build \
+            --build-arg BUILD_DATE=$(date +%Y-%m-%dT%H:%M:%S%z) \
+            --build-arg BUILD_TAG="app-${CIRCLE_SHA1}" \
+            --build-arg APP_BRANCH=${CIRCLE_BRANCH} \
+            -t app .
       - aws-cli/setup:
           role_arn: $ECR_ROLE_TO_ASSUME
           region: $ECR_REGION
@@ -106,6 +105,7 @@ commands:
               docker tag app "${ECR_REGISTRY}/${ECR_REPOSITORY}:latest"
               docker push "${ECR_REGISTRY}/${ECR_REPOSITORY}:latest"
             fi
+
   run-smoke-test:
     parameters:
       use_case:
@@ -207,8 +207,7 @@ jobs:
       - setup_remote_docker:
           version: 20.10.7
       - *decrypt_secrets
-      - *build_docker_image
-      - push-to-ecr
+      - build-and-push-to-ecr
   deploy_uat: &deploy_uat
     executor: cloud-platform-executor
     steps:

--- a/bin/uat_deploy
+++ b/bin/uat_deploy
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 deploy() {
-  IMG_REPO="$ECR_ENDPOINT/laa-apply-for-legal-aid/laa-hmrc-interface-uat-ecr"
+  IMG_REPO="${ECR_REGISTRY}/${ECR_REPOSITORY}"
   RELEASE_NAME=$(echo $CIRCLE_BRANCH | tr '[:upper:]' '[:lower:]' | sed 's:^\w*\/::' | tr -s ' _/[]().' '-' | cut -c1-30 | sed 's/-$//')
   RELEASE_HOST="$RELEASE_NAME-laa-hmrc-interface-uat.cloud-platform.service.justice.gov.uk"
   BRANCH_NAME=$(echo $CIRCLE_BRANCH | tr -s ' _/[]().' '-')


### PR DESCRIPTION
## What
Use short lived credentials (IRSA) for ECR push

[Link to story](https://dsdmoj.atlassian.net/browse/AP-4295)

Following the guide from cloud platform [migrating to short lived credentials for CircleCi](https://user-guide.cloud-platform.service.justice.gov.uk/documentation/deploying-an-app/container-repositories/deprecating-long-lived-credentials.html#migrating-to-short-lived-credentials-for-circleci).

See related PR for [Adding CircleCI OIDC provider](https://github.com/ministryofjustice/cloud-platform-environments/pull/14402)

Note, since the `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`
and `AWS_DEFAULT_REGION` still exist in the circleci environment
variables it is unclear whether they are being used. 

Only removing said variables will be a real test so this [CircleCI run](https://app.circleci.com/pipelines/github/ministryofjustice/laa-hmrc-interface-service-api/5609/workflows/e77a7dc6-750f-45d9-aea5-4281f687f981/jobs/22838) was performed after
deleting the AWS_ACCESS_KEY_ID from CircleCR env vars. It was successful.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
- You should have run `NOCOVERAGE=true rake rswag` to ensure the swagger docs are up-to-date
