### PR TITLE
Enable all new cops by default

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,6 @@
+AllCops:
+  NewCops: enable
+
 require:
   - rubocop-performance
 

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -8,7 +8,7 @@ class Submission < ApplicationRecord
 
   before_validation :normalise_nino
 
-  validates :use_case, presence: true, inclusion: { in: USE_CASES, message: "Invalid use case" }
+  validates :use_case, presence: true, inclusion: { in: USE_CASES }
   validates :first_name, presence: true
   validates :last_name, presence: true
   validate :validate_nino

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -75,7 +75,7 @@ Rails.application.configure do
   config.active_support.disallowed_deprecation_warnings = []
 
   # Use default logging formatter so that PID and timestamp are not suppressed.
-  config.log_formatter = ::Logger::Formatter.new
+  config.log_formatter = Logger::Formatter.new
 
   # Use a different logger for distributed setups.
   # require "syslog/logger"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -15,3 +15,5 @@ en:
               date_not_valid: is not a valid date
               date_is_in_the_future: is not a valid date
               invalid_timeline: is not a valid date
+            use_case:
+              inclusion: Invalid use case

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -42,5 +42,5 @@ Rails.application.routes.draw do
 end
 
 def secure_compare(passed, stored)
-  Rack::Utils.secure_compare(::Digest::SHA256.hexdigest(passed), ::Digest::SHA256.hexdigest(stored))
+  Rack::Utils.secure_compare(Digest::SHA256.hexdigest(passed), Digest::SHA256.hexdigest(stored))
 end

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe ApplicationController, type: :controller do
+RSpec.describe ApplicationController do
   include AuthorisedRequestHelper
 
   controller do

--- a/spec/models/submission_spec.rb
+++ b/spec/models/submission_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Submission, type: :model do
+RSpec.describe Submission do
   subject(:submission) { described_class.create(params) }
 
   let(:params) do

--- a/spec/requests/api/v1/smoke_test_swagger_spec.rb
+++ b/spec/requests/api/v1/smoke_test_swagger_spec.rb
@@ -1,6 +1,6 @@
 require "swagger_helper"
 
-RSpec.describe "Generate smoke_test swagger docs", type: :request, swagger_doc: "v1/swagger.yaml" do
+RSpec.describe "Generate smoke_test swagger docs", swagger_doc: "v1/swagger.yaml" do
   let(:use_case) { "one" }
 
   path "/smoke-test/{use_case}" do

--- a/spec/requests/api/v1/submissions_swagger_spec.rb
+++ b/spec/requests/api/v1/submissions_swagger_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 require "swagger_helper"
 
 RSpec.shared_examples "GET submission" do
-  describe "GET submission", type: :request do
+  describe "GET submission" do
     include AuthorisedRequestHelper
 
     let(:token) { application.access_tokens.create!(scopes: application.scopes) }
@@ -255,11 +255,11 @@ end
 # version, staging and UAT shows the "v1/swagger.yaml" version
 #
 RSpec.describe "Generate submission swagger docs" do
-  context "with API V1 Docs", type: :request, swagger_doc: "v1/live/swagger.yaml" do
+  context "with API V1 Docs", swagger_doc: "v1/live/swagger.yaml" do
     include_examples "GET submission"
   end
 
-  context "with API V1 Docs (incl. smoke tests)", type: :request, swagger_doc: "v1/swagger.yaml" do
+  context "with API V1 Docs (incl. smoke tests)", swagger_doc: "v1/swagger.yaml" do
     include_examples "GET submission"
   end
 end

--- a/spec/requests/api/v1/submissions_swagger_spec.rb
+++ b/spec/requests/api/v1/submissions_swagger_spec.rb
@@ -216,7 +216,7 @@ RSpec.shared_examples "GET submission" do
             end
             run_test! do
               expect(response.media_type).to eq("application/json")
-              expect(JSON.parse(response.body).symbolize_keys).to eq(expected_response)
+              expect(response.parsed_body.symbolize_keys).to eq(expected_response)
             end
           end
 

--- a/spec/requests/api/v1/submissions_swagger_spec.rb
+++ b/spec/requests/api/v1/submissions_swagger_spec.rb
@@ -149,7 +149,7 @@ RSpec.shared_examples "GET submission" do
 
           response 200, "Submission completed or failed" do
             context "when completed with attachment" do
-              let(:submission) { create :submission, :completed, :with_attachment, oauth_application: application }
+              let(:submission) { create(:submission, :completed, :with_attachment, oauth_application: application) }
 
               let(:expected_response) do
                 {
@@ -169,7 +169,7 @@ RSpec.shared_examples "GET submission" do
             end
 
             context "when failed with attachment" do
-              let(:submission) { create :submission, :failed_with_attachment, oauth_application: application }
+              let(:submission) { create(:submission, :failed_with_attachment, oauth_application: application) }
 
               let(:expected_response) do
                 {
@@ -190,7 +190,7 @@ RSpec.shared_examples "GET submission" do
           end
 
           response 202, "Submission still processing" do
-            let!(:submission) { create :submission, :processing, oauth_application: application }
+            let!(:submission) { create(:submission, :processing, oauth_application: application) }
             let(:expected_response) do
               {
                 submission: id,
@@ -205,7 +205,7 @@ RSpec.shared_examples "GET submission" do
           end
 
           response 500, "Submission complete but no result object is present" do
-            let!(:submission) { create :submission, :completed, oauth_application: application }
+            let!(:submission) { create(:submission, :completed, oauth_application: application) }
             let(:expected_response) do
               {
                 submission: id,
@@ -235,7 +235,7 @@ RSpec.shared_examples "GET submission" do
             response(400, "Bad request") do
               let(:submitting_application) { dk_application }
               let(:submission) do
-                create :submission, :processing, oauth_application: submitting_application
+                create(:submission, :processing, oauth_application: submitting_application)
               end
 
               run_test! do |response|

--- a/spec/requests/main_controller_spec.rb
+++ b/spec/requests/main_controller_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe MainController, type: :request do
+describe MainController do
   describe "GET /main" do
     subject(:get_main) { get main_path }
 

--- a/spec/requests/sidekiq_spec.rb
+++ b/spec/requests/sidekiq_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe "sidekiq WEB UI", type: :request do
+RSpec.describe "sidekiq WEB UI" do
   describe "GET /sidekiq" do
     it "returns unauthorized status" do
       get sidekiq_web_path

--- a/spec/requests/status_controller_spec.rb
+++ b/spec/requests/status_controller_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe StatusController do
         allow(REDIS).to receive(:ping).and_raise(Redis::CannotConnectError)
         allow(Sidekiq::ProcessSet).to receive(:new).and_return(instance_double(Sidekiq::ProcessSet, size: 0))
 
-        connection = instance_double("connection")
+        connection = instance_double(Sidekiq::RedisClientAdapter::CompatClient)
         allow(connection).to receive(:info).and_raise(Redis::CannotConnectError)
         allow(Sidekiq).to receive(:redis).and_yield(connection)
 

--- a/spec/requests/status_controller_spec.rb
+++ b/spec/requests/status_controller_spec.rb
@@ -212,7 +212,7 @@ RSpec.describe StatusController do
 
       it "returns HTTP success" do
         get "/health_check"
-        expect(response).to have_http_status(200)
+        expect(response).to have_http_status(:ok)
       end
 
       it "returns the expected response report" do

--- a/spec/requests/status_controller_spec.rb
+++ b/spec/requests/status_controller_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe StatusController, type: :request do
+RSpec.describe StatusController do
   describe "#healthcheck" do
     before do
       allow(Sidekiq::ProcessSet).to receive(:new).and_return(instance_double(Sidekiq::ProcessSet, size: 1))

--- a/spec/requests/status_controller_spec.rb
+++ b/spec/requests/status_controller_spec.rb
@@ -241,7 +241,7 @@ RSpec.describe StatusController do
       end
 
       it "returns JSON with app information" do
-        expect(JSON.parse(response.body)).to eq(expected_json)
+        expect(response.parsed_body).to eq(expected_json)
       end
     end
 
@@ -255,7 +255,7 @@ RSpec.describe StatusController do
       end
 
       it 'returns "Not Available"' do
-        expect(JSON.parse(response.body).values).to be_all("Not Available")
+        expect(response.parsed_body.values).to be_all("Not Available")
       end
     end
   end

--- a/spec/requests/status_controller_spec.rb
+++ b/spec/requests/status_controller_spec.rb
@@ -212,7 +212,7 @@ RSpec.describe StatusController do
 
       it "returns HTTP success" do
         get "/health_check"
-        expect(response.status).to eq(200)
+        expect(response).to have_http_status(200)
       end
 
       it "returns the expected response report" do

--- a/spec/services/smoke_test_spec.rb
+++ b/spec/services/smoke_test_spec.rb
@@ -11,6 +11,6 @@ RSpec.describe SmokeTest, :smoke_test do
 
   it "returns the expected output" do
     expect(use_case).to be true
-    expect(REDIS.get("smoke-test-one")).not_to be nil
+    expect(REDIS.get("smoke-test-one")).not_to be_nil
   end
 end

--- a/spec/services/submission_service_spec.rb
+++ b/spec/services/submission_service_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe SubmissionService, vcr: { cassette_name: "use_case_one_success" }
   describe ".call" do
     subject(:call) { described_class.call(submission) }
 
-    let(:submission) { create :submission, data }
+    let(:submission) { create(:submission, data) }
     let(:application) { dk_application }
     let(:data) do
       {

--- a/spec/services/use_case_spec.rb
+++ b/spec/services/use_case_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe UseCase do
       before { allow(BearerToken).to receive(:call).with("use_case_one").and_return("new_fake_token_value") }
 
       it "calls BearerToken and stores the value in redis" do
-        expect(REDIS.get("use_case_one_bearer_token")).to be nil
+        expect(REDIS.get("use_case_one_bearer_token")).to be_nil
         use_case
         expect(REDIS.get("use_case_one_bearer_token")).to eql "new_fake_token_value"
       end

--- a/spec/workers/submission_process_worker_spec.rb
+++ b/spec/workers/submission_process_worker_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe SubmissionProcessWorker do
 
   let(:worker) { described_class.new }
   let(:application) { dk_application }
-  let(:submission) { create :submission, oauth_application: application }
+  let(:submission) { create(:submission, oauth_application: application) }
 
   before do
     allow(Submission).to receive(:find).with(submission.id).and_return(submission)

--- a/spec/workers/submission_process_worker_spec.rb
+++ b/spec/workers/submission_process_worker_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe SubmissionProcessWorker do
           worker.retry_count = 0
         end
 
-        it "updates the submission status amd records the error " do
+        it "updates the submission status amd records the error" do
           submission_process_worker
           expect(submission.status).to eq("failed")
         end


### PR DESCRIPTION
## What

[HMRC API - Enable rubocop new cops](https://dsdmoj.atlassian.net/browse/AP-4287)
Enable all new cops by default.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
- You should have run `NOCOVERAGE=true rake rswag` to ensure the swagger docs are up-to-date
