### PR TITLE
Fix: remove id from factory

### DIFF
--- a/spec/factories/submission_factory.rb
+++ b/spec/factories/submission_factory.rb
@@ -1,6 +1,5 @@
 FactoryBot.define do
   factory :submission do
-    id { SecureRandom.uuid }
     status { :created }
     use_case { %i[one two three four].sample }
     first_name { Faker::Name.first_name }


### PR DESCRIPTION
## What

This will cause issues in FactoryBot 6.4.0 and higher. Removing now to allow that upgrade path to conclude

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
- You should have run `NOCOVERAGE=true rake rswag` to ensure the swagger docs are up-to-date
