### PR TITLE
Bump laa-civil-apply-delete-uat-release v1.0.2 to v1.1.0

### DIFF
--- a/.github/workflows/delete-uat-release.yml
+++ b/.github/workflows/delete-uat-release.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v3
       - name: Delete UAT release
         id: delete_uat
-        uses: ministryofjustice/laa-civil-apply-delete-uat-release@v1.0.2
+        uses: ministryofjustice/laa-civil-apply-delete-uat-release@v1.1.0
         with:
           k8s_cluster: ${{ secrets.K8S_GHA_UAT_CLUSTER_NAME }}
           k8s_cluster_cert: ${{ secrets.K8S_GHA_UAT_CLUSTER_CERT }}


### PR DESCRIPTION
## What
Bump laa-civil-apply-delete-uat-release v1.0.2 to v1.1.0

[Link to story](https://dsdmoj.atlassian.net/browse/AP-4569)

Has no impact as this repo does not uses PVCs
is not opted.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`.
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
- You should have run `NOCOVERAGE=true rake rswag` to ensure the swagger docs are up-to-date
