### PR TITLE
Fix: update DotEnv

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ gem "aws-sdk-s3", require: false
 gem "bootsnap", ">= 1.4.4", require: false
 gem "config"
 gem "doorkeeper"
-gem "dotenv-rails"
+gem "dotenv"
 gem "net-imap"
 gem "net-pop"
 gem "net-smtp"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -117,10 +117,7 @@ GEM
     domain_name (0.6.20240107)
     doorkeeper (5.6.6)
       railties (>= 5)
-    dotenv (2.8.1)
-    dotenv-rails (2.8.1)
-      dotenv (= 2.8.1)
-      railties (>= 3.2)
+    dotenv (3.0.0)
     drb (2.2.0)
       ruby2_keywords
     dry-configurable (1.1.0)
@@ -460,7 +457,7 @@ DEPENDENCIES
   byebug
   config
   doorkeeper
-  dotenv-rails
+  dotenv
   factory_bot_rails (>= 6.2.0)
   faker (>= 1.9.1)
   guard-livereload

--- a/config/application.rb
+++ b/config/application.rb
@@ -20,7 +20,7 @@ require "action_cable/engine"
 Bundler.require(*Rails.groups)
 
 # load `.env` earlier in boot sequence for use in settings.yml
-Dotenv::Railtie.load
+Dotenv::Rails.load
 
 module LaaHmrcInterfaceServiceApi
   class Application < Rails::Application


### PR DESCRIPTION
## What

The gem has been update to 3.0.0 and started a deprecation process to replace dotenv-rails with a single-use dotenv gem

closes #1701 

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`.
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
- You should have run `NOCOVERAGE=true rake rswag` to ensure the swagger docs are up-to-date
