### PR TITLE
Chore: Update dependabot groups

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,3 +14,9 @@ updates:
     rswag-gems:
       patterns:
         - "rswag-*"
+    aws-gems:
+      patterns:
+        - "aws-*"
+    rubocop-gems:
+      patterns:
+        - "rubocop-*"


### PR DESCRIPTION
## What

Add groups for rubocop and aws as there are often many gems updated at once

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`.
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
- You should have run `NOCOVERAGE=true rake rswag` to ensure the swagger docs are up-to-date
