### PR TITLE
Chore: Update circle flow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -318,18 +318,19 @@ workflows:
       - deploy_staging:
           context: laa-hmrc-interface-staging
           requires:
-            - deploy_main_uat
+            - build_and_push
       - slack/on-hold:
           requires:
+            - deploy_main_uat
             - deploy_staging
       - hold_production:
           type: approval
           requires:
+            - deploy_main_uat
             - deploy_staging
       - deploy_production:
           context: laa-hmrc-interface-production
           requires:
-            - slack/on-hold
             - hold_production
 
   smoke-tests:


### PR DESCRIPTION
## What

This aims to use the same flow for all services, so it runs the uat and staging deploys in parallel to save time.

If both deploys succeed, it sends the message to slack and allows the hold to be released.  This means that when deploying in a hurry, emergency fixes, etc; and you are waiting to deploy you are not blocked waiting for the the slack message to be sent.  It also means that if slack is offline for any reason it does not block deploys

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`.
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
- You should have run `NOCOVERAGE=true rake rswag` to ensure the swagger docs are up-to-date
