### PR TITLE
[Chore] CircleCI deprecations

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -267,7 +267,6 @@ jobs:
             ./bin/delete_dependabot_deployment
 
 workflows:
-  version: 2
   open_pr:
     jobs:
       - lint_checks:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -207,7 +207,7 @@ jobs:
           docker_layer_caching: true
       - *decrypt_secrets
       - *authenticate_k8s_live
-      - deploy:
+      - run:
           name: Helm deployment to UAT
           command: ./bin/uat_deploy
       - slack/notify:
@@ -223,7 +223,7 @@ jobs:
           docker_layer_caching: true
       - *decrypt_secrets
       - *authenticate_k8s_live
-      - deploy:
+      - run:
           name: Helm deployment to staging
           command: |
             helm upgrade laa-hmrc-interface ./deploy/helm/. \
@@ -240,7 +240,7 @@ jobs:
           docker_layer_caching: true
       - *decrypt_secrets
       - *authenticate_k8s_live
-      - deploy:
+      - run:
           name: Helm deployment to production
           command: |
             helm upgrade laa-hmrc-interface ./deploy/helm/. \


### PR DESCRIPTION
## What

- Migrated from step `deploy` to `run`, see: https://circleci.com/docs/migrate-from-deploy-to-run
- The Workflows `version` key is not required for version 2.1 configuration, see: https://circleci.com/docs/configuration-reference/#workflow-version 

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`.
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
- You should have run `NOCOVERAGE=true rake rswag` to ensure the swagger docs are up-to-date
