### PR TITLE
AP-5157: Migrate to AWS SM generated k8s secrets

### DIFF
--- a/deploy/helm/templates/_envs.tpl
+++ b/deploy/helm/templates/_envs.tpl
@@ -40,12 +40,12 @@ env:
   - name: SECRET_KEY_BASE
     valueFrom:
       secretKeyRef:
-        name: {{ template "app.fullname" . }}
+        name: hmrc-interface-secrets
         key: secretKeyBase
   - name: SETTINGS__SENTRY__DSN
     valueFrom:
       secretKeyRef:
-        name: {{ template "app.fullname" . }}
+        name: hmrc-interface-secrets
         key: settings__sentry__dsn
   - name: SETTINGS__SENTRY__ENVIRONMENT
     valueFrom:
@@ -55,12 +55,12 @@ env:
   - name: SETTINGS__SIDEKIQ__USERNAME
     valueFrom:
       secretKeyRef:
-        name: {{ template "app.fullname" . }}
+        name: hmrc-interface-secrets
         key: settings__sidekiq__username
   - name: SETTINGS__SIDEKIQ__WEB_UI_PASSWORD
     valueFrom:
       secretKeyRef:
-        name: {{ template "app.fullname" . }}
+        name: hmrc-interface-secrets
         key: settings__sidekiq__web_ui_password
   - name: SETTINGS__ENVIRONMENT
     valueFrom:
@@ -70,102 +70,102 @@ env:
   - name: SETTINGS__CREDENTIALS__USE_CASE_ONE__DESCRIPTION
     valueFrom:
       secretKeyRef:
-        name: {{ template "app.fullname" . }}
+        name: hmrc-interface-secrets
         key: settings__credentials__use_case_one__description
   - name: SETTINGS__CREDENTIALS__USE_CASE_ONE__HOST
     valueFrom:
       secretKeyRef:
-        name: {{ template "app.fullname" . }}
+        name: hmrc-interface-secrets
         key: settings__credentials__use_case_one__host
   - name: SETTINGS__CREDENTIALS__USE_CASE_ONE__HMRC_CLIENT_SECRET
     valueFrom:
       secretKeyRef:
-        name: {{ template "app.fullname" . }}
+        name: hmrc-interface-secrets
         key: settings__credentials__use_case_one__hmrc_client_secret
   - name: SETTINGS__CREDENTIALS__USE_CASE_ONE__HMRC_CLIENT_ID
     valueFrom:
       secretKeyRef:
-        name: {{ template "app.fullname" . }}
+        name: hmrc-interface-secrets
         key: settings__credentials__use_case_one__hmrc_client_id
   - name: SETTINGS__CREDENTIALS__USE_CASE_ONE__HMRC_TOTP_SECRET
     valueFrom:
       secretKeyRef:
-        name: {{ template "app.fullname" . }}
+        name: hmrc-interface-secrets
         key: settings__credentials__use_case_one__hmrc_totp_secret
   - name: SETTINGS__CREDENTIALS__USE_CASE_TWO__DESCRIPTION
     valueFrom:
       secretKeyRef:
-        name: {{ template "app.fullname" . }}
+        name: hmrc-interface-secrets
         key: settings__credentials__use_case_two__description
   - name: SETTINGS__CREDENTIALS__USE_CASE_TWO__HOST
     valueFrom:
       secretKeyRef:
-        name: {{ template "app.fullname" . }}
+        name: hmrc-interface-secrets
         key: settings__credentials__use_case_two__host
   - name: SETTINGS__CREDENTIALS__USE_CASE_TWO__HMRC_CLIENT_SECRET
     valueFrom:
       secretKeyRef:
-        name: {{ template "app.fullname" . }}
+        name: hmrc-interface-secrets
         key: settings__credentials__use_case_two__hmrc_client_secret
   - name: SETTINGS__CREDENTIALS__USE_CASE_TWO__HMRC_CLIENT_ID
     valueFrom:
       secretKeyRef:
-        name: {{ template "app.fullname" . }}
+        name: hmrc-interface-secrets
         key: settings__credentials__use_case_two__hmrc_client_id
   - name: SETTINGS__CREDENTIALS__USE_CASE_TWO__HMRC_TOTP_SECRET
     valueFrom:
       secretKeyRef:
-        name: {{ template "app.fullname" . }}
+        name: hmrc-interface-secrets
         key: settings__credentials__use_case_two__hmrc_totp_secret
   - name: SETTINGS__CREDENTIALS__USE_CASE_THREE__DESCRIPTION
     valueFrom:
       secretKeyRef:
-        name: {{ template "app.fullname" . }}
+        name: hmrc-interface-secrets
         key: settings__credentials__use_case_three__description
   - name: SETTINGS__CREDENTIALS__USE_CASE_THREE__HOST
     valueFrom:
       secretKeyRef:
-        name: {{ template "app.fullname" . }}
+        name: hmrc-interface-secrets
         key: settings__credentials__use_case_three__host
   - name: SETTINGS__CREDENTIALS__USE_CASE_THREE__HMRC_CLIENT_SECRET
     valueFrom:
       secretKeyRef:
-        name: {{ template "app.fullname" . }}
+        name: hmrc-interface-secrets
         key: settings__credentials__use_case_three__hmrc_client_secret
   - name: SETTINGS__CREDENTIALS__USE_CASE_THREE__HMRC_CLIENT_ID
     valueFrom:
       secretKeyRef:
-        name: {{ template "app.fullname" . }}
+        name: hmrc-interface-secrets
         key: settings__credentials__use_case_three__hmrc_client_id
   - name: SETTINGS__CREDENTIALS__USE_CASE_THREE__HMRC_TOTP_SECRET
     valueFrom:
       secretKeyRef:
-        name: {{ template "app.fullname" . }}
+        name: hmrc-interface-secrets
         key: settings__credentials__use_case_three__hmrc_totp_secret
   - name: SETTINGS__CREDENTIALS__USE_CASE_FOUR__DESCRIPTION
     valueFrom:
       secretKeyRef:
-        name: {{ template "app.fullname" . }}
+        name: hmrc-interface-secrets
         key: settings__credentials__use_case_four__description
   - name: SETTINGS__CREDENTIALS__USE_CASE_FOUR__HOST
     valueFrom:
       secretKeyRef:
-        name: {{ template "app.fullname" . }}
+        name: hmrc-interface-secrets
         key: settings__credentials__use_case_four__host
   - name: SETTINGS__CREDENTIALS__USE_CASE_FOUR__HMRC_CLIENT_SECRET
     valueFrom:
       secretKeyRef:
-        name: {{ template "app.fullname" . }}
+        name: hmrc-interface-secrets
         key: settings__credentials__use_case_four__hmrc_client_secret
   - name: SETTINGS__CREDENTIALS__USE_CASE_FOUR__HMRC_CLIENT_ID
     valueFrom:
       secretKeyRef:
-        name: {{ template "app.fullname" . }}
+        name: hmrc-interface-secrets
         key: settings__credentials__use_case_four__hmrc_client_id
   - name: SETTINGS__CREDENTIALS__USE_CASE_FOUR__HMRC_TOTP_SECRET
     valueFrom:
       secretKeyRef:
-        name: {{ template "app.fullname" . }}
+        name: hmrc-interface-secrets
         key: settings__credentials__use_case_four__hmrc_totp_secret
   {{- if eq .Values.deploy.settings__environment "non-live" }}
   - name: SETTINGS__SMOKE_TEST__USE_CASE_ONE__FIRST_NAME


### PR DESCRIPTION
## What
Use the AWS SM generated k8s secrets instead of the git-crypted versions

[Link to story](https://dsdmoj.atlassian.net/browse/AP-5157)

To migrate away from git-crypt to AWS SM

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`.
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
- You should have run `NOCOVERAGE=true rake rswag` to ensure the swagger docs are up-to-date
