### PR TITLE
AP-5157: Remove `deployHost` from secrets

### DIFF
--- a/deploy/helm/templates/_envs.tpl
+++ b/deploy/helm/templates/_envs.tpl
@@ -310,8 +310,5 @@ env:
   - name: SETTINGS__SENTRY__ENVIRONMENT
     value: {{ .Values.deploy.settings__sentry__environment | quote }}
   - name: HOST
-    valueFrom:
-      secretKeyRef:
-        name: {{ template "app.fullname" . }}
-        key: deployHost
+    value: {{ .Values.deploy.host | quote }}
 {{- end }}

--- a/deploy/helm/templates/secret.yaml
+++ b/deploy/helm/templates/secret.yaml
@@ -4,7 +4,6 @@ metadata:
   name: {{ template "app.fullname" . }}
 type: Opaque
 data:
-  deployHost: {{ .Values.deploy.host | b64enc | quote }}
   {{- if eq .Values.deploy.settings__environment "non-live" }}
   settings__smoke_test__use_case_one__first_name: {{ .Values.smoke_test.use_case_one.first_name | b64enc | quote }}
   settings__smoke_test__use_case_one__last_name: {{ .Values.smoke_test.use_case_one.last_name | b64enc | quote }}


### PR DESCRIPTION
## What
Remove `deployHost` from secrets

[Link to story](https://dsdmoj.atlassian.net/browse/AP-5157)

This envvar holds the ingress and is not a secret. It is visible
in the cloud-platform-environments repo if nowhere else in any event.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`.
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
- You should have run `NOCOVERAGE=true rake rswag` to ensure the swagger docs are up-to-date
