### PR TITLE
AP-5161: Remove git-crypt setup from docs

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -5,8 +5,6 @@
 * Copy the `.env` values from 1Password (hint: search `hmrc interface env`)
 * Paste the `.env` values from 1Password into a new file called `.env.development`
 * Run `bundle install`
-* Copy the symmetric key from 1Password (hint: search `hmrc interface key`)
-* Run `git-crypt unlock ~/path/to/symmetric_key`
 * Run `rake db:reset`, this will create, migrate and seed the database
 * Run the tests with `bundle exec rspec`
 * Run the server with `bundle exec rails s` \*


### PR DESCRIPTION
## What

[Remove git-crypt](https://dsdmoj.atlassian.net/browse/AP-5161)

Updated docs.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`.
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
- You should have run `NOCOVERAGE=true rake rswag` to ensure the swagger docs are up-to-date
