### PR TITLE
AP-5409: Dependabot reconfig

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,22 +1,18 @@
 version: 2
 updates:
-- package-ecosystem: bundler
-  directory: "/"
-  allow:
-    - dependency-type: "all"
-  schedule:
-    interval: daily
-    time: "21:00"
-    timezone: Europe/London
-  open-pull-requests-limit: 5
-  target-branch: main
-  groups:
-    rswag-gems:
-      patterns:
-        - "rswag-*"
-    aws-gems:
-      patterns:
-        - "aws-*"
-    rubocop-gems:
-      patterns:
-        - "rubocop-*"
+  - package-ecosystem: "bundler"
+    directory: "/"
+    allow:
+      - dependency-type: "all"
+    schedule:
+      interval: weekly
+      day: sunday
+      time: "21:00"
+      timezone: Europe/London
+    groups:
+      bundler:
+        patterns:
+          - "*"
+    open-pull-requests-limit: 5
+    reviewers:
+      - "ministryofjustice/laa-apply-for-legal-aid"

--- a/.github/workflows/dependabot-jira.yml
+++ b/.github/workflows/dependabot-jira.yml
@@ -1,0 +1,28 @@
+name: Create Jira Ticket
+
+on:
+  pull_request:
+    types:
+      - opened
+
+jobs:
+  create_jira_ticket:
+    runs-on: ubuntu-latest
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'dependencies') }}
+
+    steps:
+      - name: Login
+        uses: atlassian/gajira-login@v3
+        env:
+          JIRA_BASE_URL: ${{ secrets.JIRA_BASE_URL }}
+          JIRA_USER_EMAIL: ${{ secrets.JIRA_USER_EMAIL }}
+          JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}
+
+      - name: Create Jira Ticket
+        id: create
+        uses: atlassian/gajira-create@v3
+        with:
+          project: AP
+          issuetype: Maintenance
+          summary: "Dependabot PR in ${{ github.repository }}: ${{ github.event.pull_request.title }}"
+          description: ${{ github.event.pull_request.body }}


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-5409)

Group dependabots by package manager and schedule them to be weekly instead of daily.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`.
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
- You should have run `NOCOVERAGE=true rake rswag` to ensure the swagger docs are up-to-date
