### PR TITLE
Chore: modify `database_alive?` to use `database_exists?` instead of `active?`

### DIFF
--- a/app/controllers/status_controller.rb
+++ b/app/controllers/status_controller.rb
@@ -24,9 +24,7 @@ class StatusController < ApplicationController
 private
 
   def database_alive?
-    ActiveRecord::Base.connection.verify!
-  rescue PG::ConnectionBad
-    false
+    ActiveRecord::Base.connection.database_exists?
   end
 
   def redis_alive?

--- a/app/controllers/status_controller.rb
+++ b/app/controllers/status_controller.rb
@@ -24,7 +24,7 @@ class StatusController < ApplicationController
 private
 
   def database_alive?
-    ActiveRecord::Base.connection.active?
+    ActiveRecord::Base.connection.verify!
   rescue PG::ConnectionBad
     false
   end

--- a/spec/requests/status_controller_spec.rb
+++ b/spec/requests/status_controller_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe StatusController do
 
     context "when an postgres problem exists" do
       before do
-        allow(ActiveRecord::Base.connection).to receive(:verify!).and_raise(PG::ConnectionBad, "Error")
+        allow(ActiveRecord::Base.connection).to receive(:database_exists?).and_return(false)
 
         get "/health_check"
       end
@@ -194,7 +194,7 @@ RSpec.describe StatusController do
 
     context "when everything is ok" do
       before do
-        allow(ActiveRecord::Base.connection).to receive(:verify!).and_return(true)
+        allow(ActiveRecord::Base.connection).to receive(:database_exists?).and_return(true)
 
         get "/health_check"
       end

--- a/spec/requests/status_controller_spec.rb
+++ b/spec/requests/status_controller_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe StatusController do
 
     context "when an postgres problem exists" do
       before do
-        allow(ActiveRecord::Base.connection).to receive(:active?).and_raise(PG::ConnectionBad, "Error")
+        allow(ActiveRecord::Base.connection).to receive(:verify!).and_raise(PG::ConnectionBad, "Error")
 
         get "/health_check"
       end
@@ -194,7 +194,7 @@ RSpec.describe StatusController do
 
     context "when everything is ok" do
       before do
-        allow(ActiveRecord::Base.connection).to receive(:active?).and_return(true)
+        allow(ActiveRecord::Base.connection).to receive(:verify!).and_return(true)
 
         get "/health_check"
       end


### PR DESCRIPTION

## What
Fix /health_check endpoint - modify database_alive? to use `database_exists?` instead of `active?

`active?` can return false due to lazy loading since rails/activerecord 7.2
and this results in a `bad_gateway` error inappropriately.

To test database connectivity we can use `database_exists?!`

see [pertinent github issue](https://github.com/rails/rails/issues/52858)


## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`.
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
- You should have run `NOCOVERAGE=true rake rswag` to ensure the swagger docs are up-to-date
