### PR TITLE
Change non-prod ingresses to default-non-prod class

### DIFF
--- a/deploy/helm/values-staging.yaml
+++ b/deploy/helm/values-staging.yaml
@@ -13,7 +13,7 @@ resources:
     memory: 125Mi
 
 ingress:
-  className: default
+  className: default-non-prod
   hosts:
     - laa-hmrc-interface-staging.cloud-platform.service.justice.gov.uk
   annotations:

--- a/deploy/helm/values-uat.yaml
+++ b/deploy/helm/values-uat.yaml
@@ -13,7 +13,7 @@ resources:
     memory: 125Mi
 
 ingress:
-  className: default
+  className: default-non-prod
   annotations:
     external-dns.alpha.kubernetes.io/aws-weight: "100"
     ingressClassName: nginx


### PR DESCRIPTION
## What
Change non-prod ingresses to default-non-prod class

Following recommendations from CP.

see https://user-guide.cloud-platform.service.justice.gov.uk/documentation/other-topics/does-my-app-need-ingress.html#does-my-app-need-an-ingress


## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`.
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
- You should have run `NOCOVERAGE=true rake rswag` to ensure the swagger docs are up-to-date
