### PR TITLE
AP-6247: Use the correct host definitions!

### DIFF
--- a/deploy/helm/templates/ingress-public.yaml
+++ b/deploy/helm/templates/ingress-public.yaml
@@ -16,12 +16,12 @@ metadata:
 spec:
   ingressClassName: {{ .Values.publicIngress.className }}
   tls:
-{{- range .Values.ingress.hosts }}
+{{- range .Values.publicIngress.hosts }}
     - hosts:
-      - {{ . }}
+        - {{ . }}
 {{- end }}
   rules:
-{{- range .Values.ingress.hosts }}
+{{- range .Values.publicIngress.hosts }}
     - host: {{ . }}
       http:
         paths:


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-6247)

I had inadvertently set up the public ingress to use the other ingress host names, which were empty!

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`.
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
- You should have run `NOCOVERAGE=true rake rswag` to ensure the swagger docs are up-to-date
