### PR TITLE
Fix: Change classname back to original

### DIFF
--- a/deploy/helm/values-production.yaml
+++ b/deploy/helm/values-production.yaml
@@ -11,7 +11,7 @@ publicIngress:
   enabled: true
   hosts:
     - laa-hmrc-interface.cloud-platform.service.justice.gov.uk
-  className: default-prod
+  className: default
   whitelist:
     enabled: true
   annotations:


### PR DESCRIPTION


## What
Change classname back to original

`default-prod` does not exist:

```
IngressClassName 'default-prod' is not allowed. Allowed values: ["default", "default-non-prod", "modsec", "modsec-non-prod", "internal", "internal-non-prod", "internal-laa"]
```


## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`.
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
- You should have run `NOCOVERAGE=true rake rswag` to ensure the swagger docs are up-to-date
