### PR TITLE
Fix: Ingress names

### DIFF
--- a/deploy/helm/values-production.yaml
+++ b/deploy/helm/values-production.yaml
@@ -11,7 +11,7 @@ ingress:
     - laa-hmrc-interface.cloud-platform.service.justice.gov.uk
   className: default
   annotations:
-    external-dns.alpha.kubernetes.io/set-identifier: "laa-hmrc-interface-laa-hmrc-interface-service-api-public-laa-hmrc-interface-production-green"
+    external-dns.alpha.kubernetes.io/set-identifier: "laa-hmrc-interface-laa-hmrc-interface-service-api-laa-hmrc-interface-production-green"
     external-dns.alpha.kubernetes.io/aws-weight: "100"
     nginx.ingress.kubernetes.io/server-snippet: |
       if ($scheme = http) {

--- a/deploy/helm/values-staging.yaml
+++ b/deploy/helm/values-staging.yaml
@@ -19,7 +19,7 @@ ingress:
     - laa-hmrc-interface-staging.cloud-platform.service.justice.gov.uk
   className: default-non-prod
   annotations:
-    external-dns.alpha.kubernetes.io/set-identifier: "laa-hmrc-interface-laa-hmrc-interface-service-api-public-laa-hmrc-interface-staging-green"
+    external-dns.alpha.kubernetes.io/set-identifier: "laa-hmrc-interface-laa-hmrc-interface-service-api-laa-hmrc-interface-staging-green"
     external-dns.alpha.kubernetes.io/aws-weight: "100"
     nginx.ingress.kubernetes.io/server-snippet: |
       if ($scheme = http) {


### PR DESCRIPTION


## What

Remove `public` from the ingress names, these are a hold over from the earlier implementation where there would be two different ingresses


## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`.
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
- You should have run `NOCOVERAGE=true rake rswag` to ensure the swagger docs are up-to-date
