### PR TITLE
Fix: smoke tests

### DIFF
--- a/deploy/helm/templates/ingress.yaml
+++ b/deploy/helm/templates/ingress.yaml
@@ -12,7 +12,9 @@ metadata:
   annotations:
 {{ toYaml . | indent 4 }}
 {{- end }}
+  {{- if .Values.ingress.allowlist.enabled }}
     nginx.ingress.kubernetes.io/whitelist-source-range: {{ $.Values.ipAllowlist }}
+  {{- end }}
 spec:
   ingressClassName: {{ .Values.ingress.className }}
   tls:

--- a/deploy/helm/values-production.yaml
+++ b/deploy/helm/values-production.yaml
@@ -10,6 +10,8 @@ ingress:
   hosts:
     - laa-hmrc-interface.cloud-platform.service.justice.gov.uk
   className: default
+  allowlist:
+    enabled: true
   annotations:
     external-dns.alpha.kubernetes.io/set-identifier: "laa-hmrc-interface-laa-hmrc-interface-service-api-laa-hmrc-interface-production-green"
     external-dns.alpha.kubernetes.io/aws-weight: "100"

--- a/deploy/helm/values-staging.yaml
+++ b/deploy/helm/values-staging.yaml
@@ -18,6 +18,8 @@ ingress:
   hosts:
     - laa-hmrc-interface-staging.cloud-platform.service.justice.gov.uk
   className: default-non-prod
+  allowlist:
+    enabled: true
   annotations:
     external-dns.alpha.kubernetes.io/set-identifier: "laa-hmrc-interface-laa-hmrc-interface-service-api-laa-hmrc-interface-staging-green"
     external-dns.alpha.kubernetes.io/aws-weight: "100"

--- a/deploy/helm/values-uat.yaml
+++ b/deploy/helm/values-uat.yaml
@@ -16,6 +16,8 @@ ingress:
   path: "/"
   pathType: ImplementationSpecific
   className: default-non-prod
+  allowlist:
+    enabled: false
   annotations:
     external-dns.alpha.kubernetes.io/aws-weight: "100"
     nginx.ingress.kubernetes.io/server-snippet: |


### PR DESCRIPTION
## What

While implementing the removal of Swagger docs from the non-uat environments I implemented IP ranges on UAT too.  This has broken the smoke tests as they are run from Circle

This PR removes the allowlisting from UAT only

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`.
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
- You should have run `NOCOVERAGE=true rake rswag` to ensure the swagger docs are up-to-date
