### PR TITLE
Chore: update devsecops hook to latest version

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,9 +1,0 @@
-title = "Custom Gitleaks configuration"
-
-[[allowlists]]
-paths = [
-  "./docs/connect.md",
-]
-stopwords = [
-  "BSj8EmiuxwI1Z699CBY5_qnPxH6wq_nw1M3ZGK_wImg",
-]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,10 +1,8 @@
 repos:
   - repo: https://github.com/ministryofjustice/devsecops-hooks
-    rev: v1.6.0 # re-run prek install after changing this
+    rev: 5b00ab6401ed59fa55ff76b32cf8027c920cef46 # v2.0.1 re-run prek install after changing this
     hooks:
       - id: baseline
-        env:
-          STAGE_MODE: 'true' # This is the default, which is to check only the files that have been staged.
   - repo: local
     hooks:
       - id: rubocop


### PR DESCRIPTION
## What

Update devsecops hook to latest version
Remove gitleaks.toml as these rules are no longer needed

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`.
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
- You should have run `NOCOVERAGE=true rake rswag` to ensure the swagger docs are up-to-date
